### PR TITLE
no type checking in function call : wip

### DIFF
--- a/ramanujan-native/native/processing/Processor.cpp
+++ b/ramanujan-native/native/processing/Processor.cpp
@@ -44,7 +44,7 @@ std::unordered_map<std::string, ProcessingResult>* Processor::process(RuleEngine
 
     for(RuleEngineInputUnits* array : arrayREs) {
         ArrayRE* arrayRE = (ArrayRE*)(array);
-        ArrayValue* arrayValue = (ArrayValue*)(arrayRE->getVal());
+        ArrayValue* arrayValue = ((ArrayDataContainerValue*)(arrayRE->getVal()))->arrayValue;
         int size = arrayValue->totalSize;
         for(int i = 0; i < size; i++) {
             dataFieldOriginalData.insert(std::make_pair(&arrayValue->val[i],arrayValue->val[i]));

--- a/ramanujan-native/native/processing/conditionFunctioning/GreaterThanEqualToImpl.h
+++ b/ramanujan-native/native/processing/conditionFunctioning/GreaterThanEqualToImpl.h
@@ -24,53 +24,53 @@ public:
 };
 
 class GreaterThanEqualLeftVar : public CachedConditionFunctioning {
-    double * compareWhatValue;
+    DoublePtr * compareWhatValue;
     DataOperation* compareWithOp;
 public:
-    GreaterThanEqualLeftVar(double* compareWhatValue, DataOperation* compareWithOp) {
+    GreaterThanEqualLeftVar(DoublePtr* compareWhatValue, DataOperation* compareWithOp) {
         this->compareWhatValue = compareWhatValue;
         this->compareWithOp = compareWithOp;
     }
 
     bool operate() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue);
-        return *compareWhatValue >= compareWithOp->get();
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue->value);
+        return *compareWhatValue->value >= compareWithOp->get();
     }
 };
 
 class GreaterThanEqualRightVar : public CachedConditionFunctioning {
     DataOperation* compareWhatOp;
-    double * compareWithValue;
+    DoublePtr * compareWithValue;
 public:
-    GreaterThanEqualRightVar(DataOperation* compareWhatOp, double* compareWithValue) {
+    GreaterThanEqualRightVar(DataOperation* compareWhatOp, DoublePtr* compareWithValue) {
         this->compareWhatOp = compareWhatOp;
         this->compareWithValue = compareWithValue;
     }
 
     bool operate() override {
-        bool val = compareWhatOp->get() >= *compareWithValue;
+        bool val = compareWhatOp->get() >= *compareWithValue->value;
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue);
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue->value);
         return val;
     }
 };
 
 
 class GreaterThanEqualBothVar : public CachedConditionFunctioning {
-    double * compareWhatValue;
-    double * compareWithValue;
+    DoublePtr * compareWhatValue;
+    DoublePtr * compareWithValue;
 public:
-    GreaterThanEqualBothVar(double* compareWhatValue, double* compareWithValue) {
+    GreaterThanEqualBothVar(DoublePtr* compareWhatValue, DoublePtr* compareWithValue) {
         this->compareWhatValue = compareWhatValue;
         this->compareWithValue = compareWithValue;
     }
 
     bool operate() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue);
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue);
-        return *compareWhatValue >= *compareWithValue;
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue->value);
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue->value);
+        return *compareWhatValue->value >= *compareWithValue->value;
     }
 };
 
@@ -81,8 +81,8 @@ public:
         DataOperation* compareWhatOp = compareWhat->getDataOperation();
         DataOperation* compareWithOp = compareWith->getDataOperation();
 
-        double* compareWhatValue = compareWhat->getVar();
-        double* compareWithValue = compareWith->getVar();
+        DoublePtr* compareWhatValue = compareWhat->getVar();
+        DoublePtr* compareWithValue = compareWith->getVar();
 
 
         if(compareWhatValue != nullptr && compareWithValue != nullptr) {

--- a/ramanujan-native/native/processing/conditionFunctioning/GreaterThanImpl.h
+++ b/ramanujan-native/native/processing/conditionFunctioning/GreaterThanImpl.h
@@ -30,53 +30,53 @@ public:
 };
 
 class GreaterThanLeftVar : public CachedConditionFunctioning {
-    double * compareWhatValue;
+    DoublePtr * compareWhatValue;
     DataOperation* compareWithOp;
 public:
-    GreaterThanLeftVar(double* compareWhatValue, DataOperation* compareWithOp) {
+    GreaterThanLeftVar(DoublePtr* compareWhatValue, DataOperation* compareWithOp) {
         this->compareWhatValue = compareWhatValue;
         this->compareWithOp = compareWithOp;
     }
 
     bool operate() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue);
-        return *compareWhatValue > compareWithOp->get();
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue->value);
+        return *compareWhatValue->value > compareWithOp->get();
     }
 };
 
 class GreaterThanRightVar : public CachedConditionFunctioning {
     DataOperation* compareWhatOp;
-    double * compareWithValue;
+    DoublePtr * compareWithValue;
 public:
-    GreaterThanRightVar(DataOperation* compareWhatOp, double* compareWithValue) {
+    GreaterThanRightVar(DataOperation* compareWhatOp, DoublePtr* compareWithValue) {
         this->compareWhatOp = compareWhatOp;
         this->compareWithValue = compareWithValue;
     }
 
     bool operate() override {
-        bool val = compareWhatOp->get() > *compareWithValue;
+        bool val = compareWhatOp->get() > *compareWithValue->value;
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue);
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue->value);
         return val;
     }
 };
 
 class GreaterThanBothVar : public CachedConditionFunctioning {
-    double * compareWhatValue;
-    double * compareWithValue;
+    DoublePtr * compareWhatValue;
+    DoublePtr * compareWithValue;
 
 public:
-    GreaterThanBothVar(double* compareWhatValue, double* compareWithValue) {
+    GreaterThanBothVar(DoublePtr* compareWhatValue, DoublePtr* compareWithValue) {
         this->compareWhatValue = compareWhatValue;
         this->compareWithValue = compareWithValue;
     }
 
     bool operate() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue);
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue);
-        return *compareWhatValue > *compareWithValue;
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue->value);
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue->value);
+        return *compareWhatValue->value > *compareWithValue->value;
     }
 };
 
@@ -87,8 +87,8 @@ public:
         DataOperation* compareWhatOp = compareWhat->getDataOperation();
         DataOperation* compareWithOp = compareWith->getDataOperation();
 
-        double* compareWhatValue = compareWhat->getVar();
-        double* compareWithValue = compareWith->getVar();
+        DoublePtr* compareWhatValue = compareWhat->getVar();
+        DoublePtr* compareWithValue = compareWith->getVar();
 
         if(compareWhatValue != nullptr && compareWithValue != nullptr) {
             return new GreaterThanBothVar(compareWhatValue, compareWithValue);

--- a/ramanujan-native/native/processing/conditionFunctioning/IsEqualImpl.h
+++ b/ramanujan-native/native/processing/conditionFunctioning/IsEqualImpl.h
@@ -28,52 +28,52 @@ public:
 };
 
 class IsEqualLeftVar : public CachedConditionFunctioning {
-    double * compareWhatValue;
+    DoublePtr * compareWhatValue;
     DataOperation* compareWithOp;
 public:
-    IsEqualLeftVar(double* compareWhatValue, DataOperation* compareWithOp) {
+    IsEqualLeftVar(DoublePtr* compareWhatValue, DataOperation* compareWithOp) {
         this->compareWhatValue = compareWhatValue;
         this->compareWithOp = compareWithOp;
     }
 
     bool operate() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue);
-        return *compareWhatValue == compareWithOp->get();
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue->value);
+        return *compareWhatValue->value == compareWithOp->get();
     }
 };
 
 class IsEqualRightVar : public CachedConditionFunctioning {
     DataOperation* compareWhatOp;
-    double * compareWithValue;
+    DoublePtr * compareWithValue;
 public:
-    IsEqualRightVar(DataOperation* compareWhatOp, double* compareWithValue) {
+    IsEqualRightVar(DataOperation* compareWhatOp, DoublePtr* compareWithValue) {
         this->compareWhatOp = compareWhatOp;
         this->compareWithValue = compareWithValue;
     }
 
     bool operate() override {
-        bool val = compareWhatOp->get() == *compareWithValue;
+        bool val = compareWhatOp->get() == *compareWithValue->value;
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue);
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue->value);
         return val;
     }
 };
 
 class IsEqualBothVar : public CachedConditionFunctioning {
-    double *compareWhatValue;
-    double *compareWithValue;
+    DoublePtr *compareWhatValue;
+    DoublePtr *compareWithValue;
 public:
-    IsEqualBothVar(double *compareWhatValue, double *compareWithValue) {
+    IsEqualBothVar(DoublePtr *compareWhatValue, DoublePtr *compareWithValue) {
         this->compareWhatValue = compareWhatValue;
         this->compareWithValue = compareWithValue;
     }
 
     bool operate() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue);
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue);
-        return *compareWhatValue == *compareWithValue;
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue->value);
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue->value);
+        return *compareWhatValue->value == *compareWithValue->value;
     }
 };
 
@@ -85,8 +85,8 @@ public:
         DataOperation* compareWhatOp = compareWhat->getDataOperation();
         DataOperation* compareWithOp = compareWith->getDataOperation();
 
-        double* compareWhatValue = compareWhat->getVar();
-        double* compareWithValue = compareWith->getVar();
+        DoublePtr* compareWhatValue = compareWhat->getVar();
+        DoublePtr* compareWithValue = compareWith->getVar();
 
         if(compareWhatValue != nullptr && compareWithValue != nullptr) {
             return new IsEqualBothVar(compareWhatValue, compareWithValue);

--- a/ramanujan-native/native/processing/conditionFunctioning/LessThanEqualToImpl.h
+++ b/ramanujan-native/native/processing/conditionFunctioning/LessThanEqualToImpl.h
@@ -27,53 +27,53 @@ public:
 };
 
 class LessThanEqualLeftVar : public CachedConditionFunctioning {
-    double * compareWhatValue;
+    DoublePtr * compareWhatValue;
     DataOperation* compareWithOp;
 public:
-    LessThanEqualLeftVar(double* compareWhatValue, DataOperation* compareWithOp) {
+    LessThanEqualLeftVar(DoublePtr* compareWhatValue, DataOperation* compareWithOp) {
         this->compareWhatValue = compareWhatValue;
         this->compareWithOp = compareWithOp;
     }
 
     bool operate() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue);
-        return *compareWhatValue <= compareWithOp->get();
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue->value);
+        return *compareWhatValue->value <= compareWithOp->get();
     }
 };
 
 class LessThanEqualRightVar : public CachedConditionFunctioning {
     DataOperation* compareWhatOp;
-    double * compareWithValue;
+    DoublePtr * compareWithValue;
 public:
-    LessThanEqualRightVar(DataOperation* compareWhatOp, double* compareWithValue) {
+    LessThanEqualRightVar(DataOperation* compareWhatOp, DoublePtr* compareWithValue) {
         this->compareWhatOp = compareWhatOp;
         this->compareWithValue = compareWithValue;
     }
 
     bool operate() override {
-        bool val = compareWhatOp->get() <= *compareWithValue;
+        bool val = compareWhatOp->get() <= *compareWithValue->value;
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue);
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue->value);
         return val;
     }
 
 };
 
 class LessThanEqualBothVar : public CachedConditionFunctioning {
-    double * compareWhatValue;
-    double * compareWithValue;
+    DoublePtr * compareWhatValue;
+    DoublePtr * compareWithValue;
 public:
-    LessThanEqualBothVar(double* compareWhatValue, double* compareWithValue) {
+    LessThanEqualBothVar(DoublePtr* compareWhatValue, DoublePtr* compareWithValue) {
         this->compareWhatValue = compareWhatValue;
         this->compareWithValue = compareWithValue;
     }
 
     bool operate() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue);
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue);
-        return *compareWhatValue <= *compareWithValue;
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue->value);
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue->value);
+        return *compareWhatValue->value <= *compareWithValue->value;
     }
 };
 
@@ -84,8 +84,8 @@ public:
         DataOperation* compareWhatOp = compareWhat->getDataOperation();
         DataOperation* compareWithOp = compareWith->getDataOperation();
 
-        double* compareWhatValue = compareWhat->getVar();
-        double* compareWithValue = compareWith->getVar();
+        DoublePtr* compareWhatValue = compareWhat->getVar();
+        DoublePtr* compareWithValue = compareWith->getVar();
 
         if (compareWhatValue != nullptr && compareWithValue != nullptr) {
             return new LessThanEqualBothVar(compareWhatValue, compareWithValue);

--- a/ramanujan-native/native/processing/conditionFunctioning/LessThanImpl.h
+++ b/ramanujan-native/native/processing/conditionFunctioning/LessThanImpl.h
@@ -27,52 +27,52 @@ public:
 };
 
 class LessThanLeftVar : public CachedConditionFunctioning {
-    double *compareWhatValue;
+    DoublePtr *compareWhatValue;
     DataOperation *compareWithOp;
 public:
-    LessThanLeftVar(double *compareWhatValue, DataOperation *compareWithOp) {
+    LessThanLeftVar(DoublePtr *compareWhatValue, DataOperation *compareWithOp) {
         this->compareWhatValue = compareWhatValue;
         this->compareWithOp = compareWithOp;
     }
 
     bool operate() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue);
-        return *compareWhatValue < compareWithOp->get();
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue->value);
+        return *compareWhatValue->value < compareWithOp->get();
     }
 };
 
 class LessThanRightVar : public CachedConditionFunctioning {
     DataOperation *compareWhatOp;
-    double *compareWithValue;
+    DoublePtr *compareWithValue;
 public:
-    LessThanRightVar(DataOperation *compareWhatOp, double *compareWithValue) {
+    LessThanRightVar(DataOperation *compareWhatOp, DoublePtr *compareWithValue) {
         this->compareWhatOp = compareWhatOp;
         this->compareWithValue = compareWithValue;
     }
 
     bool operate() override {
-        bool val = compareWhatOp->get() < *compareWithValue;
+        bool val = compareWhatOp->get() < *compareWithValue->value;
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue);
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue->value);
         return val;
     }
 };
 
 class LessThanBothVar : public CachedConditionFunctioning {
-    double *compareWhatValue;
-    double *compareWithValue;
+    DoublePtr *compareWhatValue;
+    DoublePtr *compareWithValue;
 public:
-    LessThanBothVar(double *compareWhatValue, double *compareWithValue) {
+    LessThanBothVar(DoublePtr *compareWhatValue, DoublePtr *compareWithValue) {
         this->compareWhatValue = compareWhatValue;
         this->compareWithValue = compareWithValue;
     }
 
     bool operate() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue);
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue);
-        return *compareWhatValue < *compareWithValue;
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue->value);
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue->value);
+        return *compareWhatValue->value < *compareWithValue->value;
     }
 };
 
@@ -85,8 +85,8 @@ public:
         DataOperation *compareWhatOp = compareWhat->getDataOperation();
         DataOperation *compareWithOp = compareWith->getDataOperation();
 
-        double *compareWhatValue = compareWhat->getVar();
-        double *compareWithValue = compareWith->getVar();
+        DoublePtr *compareWhatValue = compareWhat->getVar();
+        DoublePtr *compareWithValue = compareWith->getVar();
 
 
         if (compareWhatValue != nullptr && compareWithValue != nullptr) {

--- a/ramanujan-native/native/processing/conditionFunctioning/NotEqualImpl.h
+++ b/ramanujan-native/native/processing/conditionFunctioning/NotEqualImpl.h
@@ -29,52 +29,52 @@ public:
 };
 
 class NotEqualLeftVar : public CachedConditionFunctioning {
-    double * compareWhatValue;
+    DoublePtr * compareWhatValue;
     DataOperation* compareWithOp;
 public:
-    NotEqualLeftVar(double* compareWhatValue, DataOperation* compareWithOp) {
+    NotEqualLeftVar(DoublePtr* compareWhatValue, DataOperation* compareWithOp) {
         this->compareWhatValue = compareWhatValue;
         this->compareWithOp = compareWithOp;
     }
 
     bool operate() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue);
-        return *compareWhatValue != compareWithOp->get();
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue->value);
+        return *compareWhatValue->value != compareWithOp->get();
     }
 };
 
 class NotEqualRightVar : public CachedConditionFunctioning {
     DataOperation* compareWhatOp;
-    double * compareWithValue;
+    DoublePtr * compareWithValue;
 public:
-    NotEqualRightVar(DataOperation* compareWhatOp, double* compareWithValue) {
+    NotEqualRightVar(DataOperation* compareWhatOp, DoublePtr* compareWithValue) {
         this->compareWhatOp = compareWhatOp;
         this->compareWithValue = compareWithValue;
     }
 
     bool operate() override {
-        bool val = compareWhatOp->get() != *compareWithValue;
+        bool val = compareWhatOp->get() != *compareWithValue->value;
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue);
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue->value);
         return val;
     }
 };
 
 class NotEqualBothVar : public CachedConditionFunctioning {
-    double * compareWhatValue;
-    double * compareWithValue;
+    DoublePtr * compareWhatValue;
+    DoublePtr * compareWithValue;
 public:
-    NotEqualBothVar(double* compareWhatValue, double* compareWithValue) {
+    NotEqualBothVar(DoublePtr* compareWhatValue, DoublePtr* compareWithValue) {
         this->compareWhatValue = compareWhatValue;
         this->compareWithValue = compareWithValue;
     }
 
     bool operate() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue);
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue);
-        return *compareWhatValue != *compareWithValue;
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWhatValue->value);
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(compareWithValue->value);
+        return *compareWhatValue->value != *compareWithValue->value;
     }
 };
 
@@ -85,8 +85,8 @@ public:
         DataOperation* compareWhatOp = compareWhat->getDataOperation();
         DataOperation* compareWithOp = compareWith->getDataOperation();
 
-        double* compareWhatValue = compareWhat->getVar();
-        double* compareWithValue = compareWith->getVar();
+        DoublePtr* compareWhatValue = compareWhat->getVar();
+        DoublePtr* compareWithValue = compareWith->getVar();
 
         if(compareWhatValue != nullptr && compareWithValue != nullptr) {
             return new NotEqualBothVar(compareWhatValue, compareWithValue);

--- a/ramanujan-native/native/processing/operatorFunctioning/AddImpl.h
+++ b/ramanujan-native/native/processing/operatorFunctioning/AddImpl.h
@@ -23,62 +23,62 @@ public:
 };
 
 class AddImplLeftVar : public CachedOperationFunctioning {
-    double *v1;
+    DoublePtr *v1;
     DataOperation *op2;
 
 public:
 
-    AddImplLeftVar(double *v1, DataOperation *op2) {
+    AddImplLeftVar(DoublePtr *v1, DataOperation *op2) {
         this->v1 = v1;
         this->op2 = op2;
     }
 
     double get() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(v1);
-        return *v1 + op2->get();
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(v1->value);
+        return *v1->value + op2->get();
     }
 };
 
 class AddImplRightVar : public CachedOperationFunctioning {
     DataOperation *op1;
-    double *v2;
+    DoublePtr *v2;
 
 public:
 
-        AddImplRightVar(DataOperation *op1, double *v2) {
+        AddImplRightVar(DataOperation *op1, DoublePtr *v2) {
             this->op1 = op1;
             this->v2 = v2;
         }
 
         double get() override {
 #ifndef DEBUG_BUILD
-            return op1->get() + *v2;
+            return op1->get() + *v2->value;
 #endif
-            double val = op1->get() + *v2;
+            double val = op1->get() + *v2->value;
             DEBUG_PRE();
-            DEBUG_ADD_DOUBLE_PTR_BEFORE(v2);
+            DEBUG_ADD_DOUBLE_PTR_BEFORE(v2->value);
             return val;
         }
 
 };
 
 class AddImplBothVar : public CachedOperationFunctioning {
-    double *v1;
-    double *v2;
+    DoublePtr *v1;
+    DoublePtr *v2;
 
 public:
 
-        AddImplBothVar(double *v1, double *v2) {
+        AddImplBothVar(DoublePtr *v1, DoublePtr *v2) {
             this->v1 = v1;
             this->v2 = v2;
         }
 
         double get() override {
             DEBUG_PRE();
-            DEBUG_ADD_DOUBLE_PTR_BEFORE(v1);
-            DEBUG_ADD_DOUBLE_PTR_BEFORE(v2);
-            return *v1 + *v2;
+            DEBUG_ADD_DOUBLE_PTR_BEFORE(v1->value);
+            DEBUG_ADD_DOUBLE_PTR_BEFORE(v2->value);
+            return *v1->value + *v2->value;
         }
     };
 
@@ -89,8 +89,8 @@ public:
         DataOperation* op1 = commandRe1->getDataOperation();
         DataOperation* op2 = commandRe2->getDataOperation();
 
-        double *v1 = commandRe1->getVar();
-        double *v2 = commandRe2->getVar();
+        DoublePtr *v1 = commandRe1->getVar();
+        DoublePtr *v2 = commandRe2->getVar();
 
         if (v1 != nullptr && v2 != nullptr) {
             return new AddImplBothVar(v1, v2);

--- a/ramanujan-native/native/processing/operatorFunctioning/AssignImpl.h
+++ b/ramanujan-native/native/processing/operatorFunctioning/AssignImpl.h
@@ -46,26 +46,26 @@ public:
 
 //take ispiration from AddImpl and have the impl classes
 class AssignImplLeftVar : public AssignImplCachedOperationFunctioningBase {
-    double *v1;
+    DoublePtr *v1;
     DataOperation *op2;
 
 public:
 
-    AssignImplLeftVar(double *v1, DataOperation *op2) {
+    AssignImplLeftVar(DoublePtr *v1, DataOperation *op2) {
         this->v1 = v1;
         this->op2 = op2;
     }
 
     double get() override {
-        *v1 = op2->get();
+        *v1->value = op2->get();
         return 0;
     }
 
     void set() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(v1);
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(v1->value);
         double val = op2->get();
-        *v1 = val;
+        *v1->value = val;
         DEBUG_ADD_DATA_DOUBLE_SET_AFTER(val);
     }
 
@@ -73,50 +73,50 @@ public:
 
 class AssignImplRightVar : public AssignImplCachedOperationFunctioningBase {
     DataOperation *op1;
-    double *v2;
+    DoublePtr *v2;
 
 public:
 
-    AssignImplRightVar(DataOperation *op1, double *v2) {
+    AssignImplRightVar(DataOperation *op1, DoublePtr *v2) {
         this->op1 = op1;
         this->v2 = v2;
     }
 
     double get() override {
-        op1->set(*v2);
+        op1->set(*v2->value);
         return 0;
     }
 
     void set() override {
         DEBUG_PRE();
         DEBUG_ADD_DATA_OP_SET_BEFORE(op1);
-        double val = *v2;
+        double val = *v2->value;
         op1->set(val);
         DEBUG_ADD_DATA_DOUBLE_SET_AFTER(val);
     }
 };
 
 class AssignImplBothVar : public AssignImplCachedOperationFunctioningBase {
-    double *v1;
-    double *v2;
+    DoublePtr *v1;
+    DoublePtr *v2;
 
 public:
 
-    AssignImplBothVar(double *v1, double *v2) {
+    AssignImplBothVar(DoublePtr *v1, DoublePtr *v2) {
         this->v1 = v1;
         this->v2 = v2;
     }
 
     double get() override {
-        *v1 = *v2;
+        *v1->value = *v2->value;
         return 0;
     }
 
     void set() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(v1);
-        double val = *v2;
-        *v1 = val;
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(v1->value);
+        double val = *v2->value;
+        *v1->value = val;
         DEBUG_ADD_DATA_DOUBLE_SET_AFTER(val);
     }
 };
@@ -128,8 +128,8 @@ public:
         DataOperation *op1 = commandRe1->getDataOperation();
         DataOperation *op2 = commandRe2->getDataOperation();
 
-        double *v1 = commandRe1->getVar();
-        double *v2 = commandRe2->getVar();
+        DoublePtr *v1 = commandRe1->getVar();
+        DoublePtr *v2 = commandRe2->getVar();
 
 
         if (v1 != nullptr && v2 != nullptr) {

--- a/ramanujan-native/native/processing/operatorFunctioning/DivideImpl.h
+++ b/ramanujan-native/native/processing/operatorFunctioning/DivideImpl.h
@@ -27,55 +27,55 @@ public:
 
 
 class DivideImplLeftVar : public CachedOperationFunctioning {
-    double * v1;
+    DoublePtr * v1;
     DataOperation* op2;
 public:
 
-    DivideImplLeftVar(double * v1, DataOperation* op2) {
+    DivideImplLeftVar(DoublePtr * v1, DataOperation* op2) {
         this->v1 = v1;
         this->op2 = op2;
     }
 
     double get() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(v1);
-        return *v1 / op2->get();
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(v1->value);
+        return *v1->value / op2->get();
     }
 };
 
 class DivideImplRightVar : public CachedOperationFunctioning {
     DataOperation* op1;
-    double * v2;
+    DoublePtr * v2;
 public:
 
-    DivideImplRightVar(DataOperation* op1, double * v2) {
+    DivideImplRightVar(DataOperation* op1, DoublePtr * v2) {
         this->op1 = op1;
         this->v2 = v2;
     }
 
     double get() override {
-        double val = op1->get() / *v2;
+        double val = op1->get() / *v2->value;
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(v2);
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(v2->value);
         return val;
     }
 };
 
 class DivideImplBothVar : public CachedOperationFunctioning {
-    double * v1;
-    double * v2;
+    DoublePtr * v1;
+    DoublePtr * v2;
 public:
 
-    DivideImplBothVar(double * v1, double * v2) {
+    DivideImplBothVar(DoublePtr * v1, DoublePtr * v2) {
         this->v1 = v1;
         this->v2 = v2;
     }
 
     double get() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(v1);
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(v2);
-        return *v1 / *v2;
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(v1->value);
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(v2->value);
+        return *v1->value / *v2->value;
     }
 };
 
@@ -86,8 +86,8 @@ public:
         DataOperation* op1 = commandRe1->getDataOperation();
         DataOperation* op2 = commandRe2->getDataOperation();
 
-        double *v1 = commandRe1->getVar();
-        double * v2 = commandRe2->getVar();
+        DoublePtr *v1 = commandRe1->getVar();
+        DoublePtr * v2 = commandRe2->getVar();
 
         if (v1 != nullptr && v2 != nullptr) {
             return new DivideImplBothVar(v1, v2);

--- a/ramanujan-native/native/processing/operatorFunctioning/MinusImpl.h
+++ b/ramanujan-native/native/processing/operatorFunctioning/MinusImpl.h
@@ -30,59 +30,59 @@ public:
 
 
 class MinusImplLeftVar : public CachedOperationFunctioning {
-    double *v1;
+    DoublePtr *v1;
     DataOperation *op2;
 
 public:
 
-    MinusImplLeftVar(double *v1, DataOperation *op2) {
+    MinusImplLeftVar(DoublePtr *v1, DataOperation *op2) {
         this->v1 = v1;
         this->op2 = op2;
     }
 
     double get() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(v1);
-        return *v1 - op2->get();
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(v1->value);
+        return *v1->value - op2->get();
     }
 
 };
 
 class MinusImplRightVar : public CachedOperationFunctioning {
     DataOperation *op1;
-    double *v2;
+    DoublePtr *v2;
 
 public:
 
-    MinusImplRightVar(DataOperation *op1, double *v2) {
+    MinusImplRightVar(DataOperation *op1, DoublePtr *v2) {
         this->op1 = op1;
         this->v2 = v2;
     }
 
     double get() override {
-        double val = op1->get() - *v2;
+        double val = op1->get() - *v2->value;
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(v2);
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(v2->value);
         return val;
     }
 };
 
 class MinusImplBothVar : public CachedOperationFunctioning {
-    double *v1;
-    double *v2;
+    DoublePtr *v1;
+    DoublePtr *v2;
 
 public:
 
-    MinusImplBothVar(double *v1, double *v2) {
+    MinusImplBothVar(DoublePtr *v1, DoublePtr *v2) {
         this->v1 = v1;
         this->v2 = v2;
     }
 
     double get() override {
         DEBUG_PRE();
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(v1);
-        DEBUG_ADD_DOUBLE_PTR_BEFORE(v2);
-        return *v1 - *v2;
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(v1->value);
+        DEBUG_ADD_DOUBLE_PTR_BEFORE(v2->value);
+        return *v1->value - *v2->value;
     }
 };
 
@@ -94,8 +94,8 @@ public:
         DataOperation *operand1Op = operandCommandRE1->getDataOperation();
         DataOperation *operand2Op = operandCommandRE2->getDataOperation();
 
-        double *v1 = operandCommandRE1->getVar();
-        double *v2 = operandCommandRE2->getVar();
+        DoublePtr *v1 = operandCommandRE1->getVar();
+        DoublePtr *v2 = operandCommandRE2->getVar();
 
         if (v1 != nullptr && v2 != nullptr) {
             return new MinusImplBothVar(v1, v2);

--- a/ramanujan-native/native/processing/operatorFunctioning/MultiplyImpl.h
+++ b/ramanujan-native/native/processing/operatorFunctioning/MultiplyImpl.h
@@ -26,55 +26,55 @@ public:
 };
 
 class MultiplyImplLeftVar : public CachedOperationFunctioning {
-    double * v1;
+    DoublePtr * v1;
     DataOperation* op2;
 public:
 
-        MultiplyImplLeftVar(double * v1, DataOperation* op2) {
+        MultiplyImplLeftVar(DoublePtr * v1, DataOperation* op2) {
             this->v1 = v1;
             this->op2 = op2;
         }
 
         double get() override {
             DEBUG_PRE();
-            DEBUG_ADD_DOUBLE_PTR_BEFORE(v1);
-            return *v1 * op2->get();
+            DEBUG_ADD_DOUBLE_PTR_BEFORE(v1->value);
+            return *v1->value * op2->get();
         }
     };
 
 class MultiplyImplRightVar : public CachedOperationFunctioning {
     DataOperation* op1;
-    double * v2;
+    DoublePtr * v2;
 public:
 
-        MultiplyImplRightVar(DataOperation* op1, double * v2) {
+        MultiplyImplRightVar(DataOperation* op1, DoublePtr * v2) {
             this->op1 = op1;
             this->v2 = v2;
         }
 
         double get() override {
-            double val = op1->get() * *v2;
+            double val = op1->get() * *v2->value;
             DEBUG_PRE();
-            DEBUG_ADD_DOUBLE_PTR_BEFORE(v2);
+            DEBUG_ADD_DOUBLE_PTR_BEFORE(v2->value);
             return val;
         }
 };
 
 class MultiplyImplBothVar : public CachedOperationFunctioning {
-    double * v1;
-    double * v2;
+    DoublePtr * v1;
+    DoublePtr * v2;
 public:
 
-        MultiplyImplBothVar(double * v1, double * v2) {
+        MultiplyImplBothVar(DoublePtr * v1, DoublePtr * v2) {
             this->v1 = v1;
             this->v2 = v2;
         }
 
         double get() override {
             DEBUG_PRE();
-            DEBUG_ADD_DOUBLE_PTR_BEFORE(v1);
-            DEBUG_ADD_DOUBLE_PTR_BEFORE(v2);
-            return *v1 * *v2;
+            DEBUG_ADD_DOUBLE_PTR_BEFORE(v1->value);
+            DEBUG_ADD_DOUBLE_PTR_BEFORE(v2->value);
+            return *v1->value * *v2->value;
         }
 };
 
@@ -85,8 +85,8 @@ public:
         DataOperation* op1 = commandRe1->getDataOperation();
         DataOperation* op2 = commandRe2->getDataOperation();
 
-        double *v1 = commandRe1->getVar();
-        double *v2 = commandRe2->getVar();
+        DoublePtr *v1 = commandRe1->getVar();
+        DoublePtr *v2 = commandRe2->getVar();
 
         if (v1 != nullptr && v2 != nullptr) {
             return new MultiplyImplBothVar(v1, v2);

--- a/ramanujan-native/native/ruleEngineObject/ArrayCommandRE.h
+++ b/ramanujan-native/native/ruleEngineObject/ArrayCommandRE.h
@@ -24,30 +24,32 @@ public:
 class ArrayCommandRE : public DataOperation {
 private:
     ArrayRE* arrayRe;
+    ArrayDataContainerValue* arrayDataContainerValue;
     std::vector<std::string*>* index;
-    double** valPtrArr;
+    DoublePtr** valPtrArr;
 
     int dimensionSize;
     int* dimensionIndex;
 
     double * getArrayValueDataContainer() {
         int translatedIndex = 0;
-        ArrayValue * arrayVal = arrayRe->arrayValue;
+        ArrayValue * arrayVal = arrayDataContainerValue->arrayValue;
         int *sizeAtIndex = arrayVal->sizeAtIndex;
         //indexes can be only variables.
         for (int i = 0; i < (dimensionSize - 1); i++) {
 
-            int indexVal = *valPtrArr[i];//(int) dataContainers[i]->get();
+            int indexVal = *valPtrArr[i]->value;//(int) dataContainers[i]->get();
             translatedIndex += sizeAtIndex[i] * indexVal;
         }
-        translatedIndex += *valPtrArr[dimensionSize - 1];//(int) dataContainers[dimensionSize - 1]->get();
+        translatedIndex += *valPtrArr[dimensionSize - 1]->value;//(int) dataContainers[dimensionSize - 1]->get();
         return arrayVal->val + translatedIndex;
     }
 
 public:
     ArrayCommandRE(ArrayRE *arrayRe, std::vector<std::string*> *index, std::unordered_map<std::string, RuleEngineInputUnits *> *pMap) {
         this->arrayRe = arrayRe;
-        valPtrArr = new double *[index->size()];
+        arrayDataContainerValue = (ArrayDataContainerValue*) arrayRe->getVal();
+        valPtrArr = new DoublePtr *[index->size()];
 
         dimensionSize = 0;
         for (auto i : *index) {
@@ -58,10 +60,10 @@ public:
             VariableRE* var = dynamic_cast<VariableRE*>(iterator->second);
 //            dataContainers[dimensionSize] = dataContainerRe;
             if(var != nullptr) {
-                valPtrArr[dimensionSize] = var->getValPtrPtr();
+                valPtrArr[dimensionSize] = (DoublePtr*)var->getVal();
             } else {
                 ConstantRE* constant = dynamic_cast<ConstantRE*>(iterator->second);
-                valPtrArr[dimensionSize] = constant->getValPtrPtr();
+                valPtrArr[dimensionSize] = (DoublePtr*)constant->getVal();
             }
             dimensionSize++;
         }

--- a/ramanujan-native/native/ruleEngineObject/CommandRE.cpp
+++ b/ramanujan-native/native/ruleEngineObject/CommandRE.cpp
@@ -137,16 +137,16 @@ bool CommandRE::evalCondition() {
     return conditionRe->operate();
 }
 
-double* CommandRE::getVar() {
+DoublePtr * CommandRE::getVar() {
     if(getDataOperation() != nullptr) {
         return nullptr;
     }
     if(variableRE != nullptr) {
-        return variableRE->getValPtrPtr();
+        return (DoublePtr* )variableRE->getVal();
     }
 
     if(constantRE != nullptr){
-        return constantRE->getValPtrPtr();
+        return (DoublePtr* )constantRE->getVal();
 
     }
 }

--- a/ramanujan-native/native/ruleEngineObject/CommandRE.h
+++ b/ramanujan-native/native/ruleEngineObject/CommandRE.h
@@ -54,7 +54,7 @@ public:
     void process() override;
     CommandRE* get();
     DataOperation *getDataOperation();
-    double* getVar();
+    DoublePtr * getVar();
     bool evalCondition();
 
     void destroy() override {

--- a/ramanujan-native/native/ruleEngineObject/FunctionCommandRE.cpp
+++ b/ramanujan-native/native/ruleEngineObject/FunctionCommandRE.cpp
@@ -463,22 +463,6 @@ void FunctionCommandRE::process() {
     }
 
     /*
-     * MEMORY CLEANUP:
-     * 
-     * Clean up the stack management memory allocated for this function call.
-     * Each recursive call allocates its own dataContainerStackCurrent array,
-     * so each must clean up its own allocation.
-     * 
-     * RECURSIVE SAFETY:
-     * This cleanup only affects the current call level.
-     * Other recursive levels have their own separate allocations.
-     */
-    for(int i = 0; i < argSize; i++) {
-        delete dataContainerStackCurrent[i];
-    }
-    delete[] dataContainerStackCurrent;
-
-    /*
      * RECURSIVE EXECUTION COMPLETE:
      * 
      * At this point, the current function call is completely unwound:

--- a/ramanujan-native/native/ruleEngineObject/FunctionCommandRE.cpp
+++ b/ramanujan-native/native/ruleEngineObject/FunctionCommandRE.cpp
@@ -5,12 +5,26 @@
 #include "FunctionCommandRE.h"
 #include "dataContainer/ArrayRE.h"
 #include "dataContainer/VariableRE.h"
+#include "dataContainer/array/ArrayValue.h"
 #include "DebugPoint.h"
 #include <list>
 
 #include <limits>
 #include <random>
 
+/*
+         * PARAMETER PASSING: Copy argument value to function parameter (CALL-BY-REFERENCE)
+         * 
+         * Example: increment_recursive(level 2) call
+         * - methodCallingOriginalPlaceHolderAddrs[0] contains value 7 (from level 1)
+         * - methodCallingOriginalPlaceHolderAddrs[1] contains value 1 (from level 1's tmpVar)
+         * - methodCalledOriginalPlaceHolderAddrs[0] is level 2's parameter n
+         * - methodCalledOriginalPlaceHolderAddrs[1] is level 2's parameter depth
+         * - After this: level 2's n = 7, depth = 1
+         * 
+         * CALL-BY-REFERENCE: Any modifications to n or depth in level 2 will be 
+         * visible to level 1 when control returns, because they point to the same memory.
+         */
 FunctionCommandRE::FunctionCommandRE(FunctionCall* functionCommand, FunctionCallRE* functionInfo) {
     this->functionCommandInfo = functionCommand;
     this->functionInfoRE = functionInfo;
@@ -37,35 +51,34 @@ void FunctionCommandRE::setFields(std::unordered_map<std::string, RuleEngineInpu
 
 
     /*
-     * Demarcate the functionInfoRE->argument in variables and arrays.
+     * Set up parameter mapping using unified DataContainerValue approach.
+     * Use the valPtrPtr mechanism as designed for function parameter passing.
      */
 
-    std::list<double*> methodCalledOriginalPlaceHolderAddrsList;
-    std::list<ArrayValue**> methodCalledArrayPlaceHolderAddrsList;
-
-    std::list<double*> methodCallingOriginalPlaceHolderAddrsList;
-    std::list<ArrayValue**> methodCallingArrayPlaceHolderAddrsList;
+    std::list<DataContainerValue*> methodCalledOriginalPlaceHolderAddrsList;
+    std::list<DataContainerValue*> methodCallingOriginalPlaceHolderAddrsList;
 
     for(int i = 0; i < functionInfoRE->argSize; i++) {
+        AbstractDataContainer* calledArg = dynamic_cast<AbstractDataContainer*>(functionInfoRE->arguments[i]);
+        AbstractDataContainer* callingArg = dynamic_cast<AbstractDataContainer*>(map->at(functionCommandInfo->arguments[i]));
+        
+        methodCalledOriginalPlaceHolderAddrsList.push_back(calledArg->valPtr);
+        methodCallingOriginalPlaceHolderAddrsList.push_back(callingArg->valPtr);
+        
+        // Build name mapping for debugging (works for both variables and arrays)
         if(dynamic_cast<ArrayRE*>(functionInfoRE->arguments[i]) != nullptr) {
             arrCount++;
-            methodCalledArrayPlaceHolderAddrsList.push_back(((ArrayRE*)functionInfoRE->arguments[i])->getValPtr());
-            methodCallingArrayPlaceHolderAddrsList.push_back(((ArrayRE*)map->at(functionCommandInfo->arguments[i]))->getValPtr());
-            arrayNameMethodMap.insert(std::make_pair(((ArrayRE *) map->at(functionCommandInfo->arguments[i]))->name,
+            dataContainerNameMethodMap.insert(std::make_pair(((ArrayRE *) map->at(functionCommandInfo->arguments[i]))->name,
                                                 ((ArrayRE *) functionInfoRE->arguments[i])->name));
         } else {
             varCount++;
-            methodCalledOriginalPlaceHolderAddrsList.push_back(((DoublePtr*)functionInfoRE->arguments[i])->getValPtrPtr());
-            methodCallingOriginalPlaceHolderAddrsList.push_back(((DoublePtr*)map->at(functionCommandInfo->arguments[i]))->getValPtrPtr());
         }
     }
 
-    methodCallingOriginalPlaceHolderAddrs = new double*[varCount];
-    methodCallingArrayPlaceHolderAddrs = new ArrayValue**[arrCount];
-    methodCalledOriginalPlaceHolderAddrs = new double*[varCount];
-    methodCalledArrayPlaceHolderAddrs = new ArrayValue**[arrCount];
+    methodCallingOriginalPlaceHolderAddrs = new DataContainerValue*[argSize];
+    methodCalledOriginalPlaceHolderAddrs = new DataContainerValue*[argSize];
 
-    for(int i = 0; i < varCount; i++) {
+    for(int i = 0; i < argSize; i++) {
         methodCalledOriginalPlaceHolderAddrs[i] = methodCalledOriginalPlaceHolderAddrsList.front();
         methodCalledOriginalPlaceHolderAddrsList.pop_front();
 
@@ -73,127 +86,249 @@ void FunctionCommandRE::setFields(std::unordered_map<std::string, RuleEngineInpu
         methodCallingOriginalPlaceHolderAddrsList.pop_front();
     }
 
-    for(int i = 0; i < arrCount; i++) {
-        methodCalledArrayPlaceHolderAddrs[i] = methodCalledArrayPlaceHolderAddrsList.front();
-        methodCalledArrayPlaceHolderAddrsList.pop_front();
-
-        methodCallingArrayPlaceHolderAddrs[i] = methodCallingArrayPlaceHolderAddrsList.front();
-        methodCallingArrayPlaceHolderAddrsList.pop_front();
-    }
-
-    std::list<double*> methodArgVariableAddrList;
-    std::list<ArrayValue**> methodArgArrayAddrList;
+    std::list<DataContainerValue*> methodArgDataContainerAddrList;
 
     for(int i = 0; i < functionInfoRE->functionCall->allVariablesInMethodSize; i++) {
+        AbstractDataContainer* dataContainer = dynamic_cast<AbstractDataContainer*>(functionInfoRE->allVariablesInMethod[i]);
+        methodArgDataContainerAddrList.push_back(dataContainer->valPtr);
+        
         if(dynamic_cast<ArrayRE*>(functionInfoRE->allVariablesInMethod[i]) != nullptr) {
             totalArrCount++;
-            methodArgArrayAddrList.push_back(((ArrayRE*)functionInfoRE->allVariablesInMethod[i])->getValPtr());
         } else {
             totalVarCount++;
-            methodArgVariableAddrList.push_back(((DoublePtr*)functionInfoRE->allVariablesInMethod[i])->getValPtrPtr());
         }
     }
 
-    methodArgVariableAddr = new double*[totalVarCount];
-    methodArgArrayAddr = new double**[totalArrCount];
-    methodArgArrayTotalSize = new int[totalArrCount];
+    int totalDataContainerCount = totalVarCount + totalArrCount;
+    methodArgDataContainerAddr = new DataContainerValue*[totalDataContainerCount];
+    methodArgDataContainerCurrentVal = new DataContainerValue*[totalDataContainerCount];
 
-    methodArgVariableCurrentVal = new double[totalVarCount];
-    methodArgArrayCurrentVal = new double*[totalArrCount];
-
-    for(int i = 0; i < totalVarCount; i++) {
-        methodArgVariableAddr[i] = methodArgVariableAddrList.front();
-        methodArgVariableAddrList.pop_front();
+    for(int i = 0; i < totalDataContainerCount; i++) {
+        methodArgDataContainerAddr[i] = methodArgDataContainerAddrList.front();
+        methodArgDataContainerAddrList.pop_front();
+        
+        // Create appropriate DataContainerValue copy for saving current state
+        if(dynamic_cast<DoublePtr*>(methodArgDataContainerAddr[i]) != nullptr) {
+            methodArgDataContainerCurrentVal[i] = new DoublePtr();
+        } else if(dynamic_cast<ArrayDataContainerValue*>(methodArgDataContainerAddr[i]) != nullptr) {
+            methodArgDataContainerCurrentVal[i] = new ArrayDataContainerValue();
+        }
     }
-    for(int i = 0; i < totalArrCount; i++) {
-        methodArgArrayAddr[i] = &(*methodArgArrayAddrList.front())->val;
-        methodArgArrayTotalSize[i] = (*methodArgArrayAddrList.front())->totalSize;
-        methodArgArrayAddrList.pop_front();
+    
+    dataContainerStackCurrent = new DataContainerValue*[argSize];
+    for(int i = 0; i < argSize; i++) {
+        // Create appropriate DataContainerValue copy for stack management
+        if(dynamic_cast<DoublePtr*>(methodCalledOriginalPlaceHolderAddrs[i]) != nullptr) {
+            dataContainerStackCurrent[i] = new DoublePtr();
+        } else if(dynamic_cast<ArrayDataContainerValue*>(methodCalledOriginalPlaceHolderAddrs[i]) != nullptr) {
+            dataContainerStackCurrent[i] = new ArrayDataContainerValue();
+        }
     }
-    variableStackCurrent = new double[varCount];
-    arrayStackCurrent = new ArrayValue*[arrCount];
 }
 
 void FunctionCommandRE::process() {
+    /*
+     * ==================== EXHAUSTIVE EXAMPLE: RECURSIVE FUNCTION EXECUTION ====================
+     * 
+     * Let's trace through how this process() method would execute a recursive function similar to:
+     * 
+     * def increment_recursive(n, depth):
+     *     if depth <= 0:
+     *         return  # Base case - modify n in place
+     *     else:
+     *         n = n + 1  # Increment n (call-by-reference)
+     *         tmpVar = depth - 1  # Operations must be separate assignments
+     *         increment_recursive(n, tmpVar)  # Recursive call with variables only
+     * 
+     * # Usage (standalone function calls):
+     * x = 5
+     * increment_recursive(x, 3)  # x becomes 8 after execution
+     * 
+     * CALL STACK VISUALIZATION:
+     * 
+     * 1. increment_recursive(x=5, depth=3) called:
+     *    - Parameters: n = 5, depth = 3
+     *    - Local variables: tmpVar
+     *    - Executes: n = n + 1 (n becomes 6), tmpVar = depth - 1 (tmpVar becomes 2), then calls increment_recursive(n, tmpVar)
+     * 
+     * 2. increment_recursive(n=6, depth=2) called (RECURSIVE):
+     *    - Parameters: n = 6, depth = 2  
+     *    - Local variables: tmpVar
+     *    - Executes: n = n + 1 (n becomes 7), tmpVar = depth - 1 (tmpVar becomes 1), then calls increment_recursive(n, tmpVar)
+     * 
+     * 3. increment_recursive(n=7, depth=1) called (RECURSIVE):
+     *    - Parameters: n = 7, depth = 1
+     *    - Local variables: tmpVar
+     *    - Executes: n = n + 1 (n becomes 8), tmpVar = depth - 1 (tmpVar becomes 0), then calls increment_recursive(n, tmpVar)
+     * 
+     * 4. increment_recursive(n=8, depth=0) called (RECURSIVE):
+     *    - Parameters: n = 8, depth = 0
+     *    - Local variables: tmpVar
+     *    - Executes: if depth <= 0, return (base case reached)
+     * 
+     * IMPORTANT: NO RETURN VALUES - ALL MODIFICATION IS CALL-BY-REFERENCE
+     * Each function modifies its parameters directly, and these changes are visible
+     * to the calling function because arguments are passed by reference.
+     * 
+     * MEMORY LAYOUT DURING EXECUTION:
+     * 
+     * methodCalledOriginalPlaceHolderAddrs[0] -> points to function parameter 'n'
+     * methodCalledOriginalPlaceHolderAddrs[1] -> points to function parameter 'depth'
+     * methodCallingOriginalPlaceHolderAddrs[0] -> points to calling argument 'n'
+     * methodCallingOriginalPlaceHolderAddrs[1] -> points to calling argument 'depth'
+     * methodArgDataContainerAddr[0] -> parameter 'n' 
+     * methodArgDataContainerAddr[1] -> parameter 'depth'
+     * methodArgDataContainerAddr[2] -> local variable 'tmpVar'
+     * 
+     * CRITICAL STACK MANAGEMENT:
+     * Each recursive call creates its own process() execution with separate:
+     * - dataContainerStackCurrent[] arrays for parameter backup
+     * - methodArgDataContainerCurrentVal[] arrays for local variable backup
+     * - Proper restoration order to prevent data corruption
+     */
+
     // ==================== DEBUG SETUP ====================
 #ifdef DEBUG_BUILD
     // Get debug point for tracking function call execution
     std::shared_ptr<DebugPoint> debugPoint = debugger->getDebugPointToBeCommitted();
 #endif
 
-    // ==================== PHASE 1: PARAMETER SETUP AND VARIABLE CONTEXT SAVING ====================
+    // ==================== PHASE 1: PARAMETER SETUP AND DATA CONTAINER CONTEXT SAVING ====================
     
     /*
-     * For each variable parameter passed to the function:
-     * 1. Save the current value of the called function's parameter variable (for stack restoration)
-     * 2. Copy the calling function's argument value to the called function's parameter
-     * 3. Save the current state of the parameter variable for later restoration
+     * RECURSIVE EXAMPLE - PHASE 1 DETAILS:
+     * 
+     * For increment_recursive(x=6, depth=2) -> increment_recursive(n=6, depth=1) call:
+     * 
+     * BEFORE PHASE 1:
+     * - increment_recursive(level 1)'s parameter n = 6, depth = 2
+     * - About to call increment_recursive(level 2), so arguments are n=7, tmpVar=1
+     * 
+     * DURING PHASE 1:
+     * 1. dataContainerStackCurrent[0] saves current value of increment_recursive(level 2)'s parameter n (could be garbage)
+     * 2. dataContainerStackCurrent[1] saves current value of increment_recursive(level 2)'s parameter depth (could be garbage)
+     * 3. increment_recursive(level 2)'s parameter n gets copied value 7 from calling argument
+     * 4. increment_recursive(level 2)'s parameter depth gets copied value 1 from calling argument (tmpVar)
+     * 
+     * AFTER PHASE 1:
+     * - increment_recursive(level 2)'s parameters: n = 7, depth = 1 (ready for execution)
+     * - increment_recursive(level 1)'s context is preserved in calling arrays
+     * 
+     * MEMORY STATE:
+     * methodCalledOriginalPlaceHolderAddrs[0] -> increment_recursive(level 2)'s parameter n (now = 7)
+     * methodCalledOriginalPlaceHolderAddrs[1] -> increment_recursive(level 2)'s parameter depth (now = 1)
+     * methodCallingOriginalPlaceHolderAddrs[0] -> increment_recursive(level 1)'s argument value (7)
+     * methodCallingOriginalPlaceHolderAddrs[1] -> increment_recursive(level 1)'s argument value (1)
+     * dataContainerStackCurrent[0] -> backup of increment_recursive(level 2)'s original n value
+     * dataContainerStackCurrent[1] -> backup of increment_recursive(level 2)'s original depth value
      */
-    for (int i = 0; i < varCount; i++) {
+    
+    /*
+     * For each parameter passed to the function:
+     * 1. Save the original DataContainerValue content that the parameter contains (for restoration)
+     * 2. Copy the calling argument's DataContainerValue content to the called function's parameter
+     * 3. Save the current state of all data containers for later restoration
+     */
+    for (int i = 0; i < argSize; i++) {
 #ifdef DEBUG_BUILD
-        // Record the current function variable value for debugging
-        debugPoint->addCurrentFuncVal(*methodCallingOriginalPlaceHolderAddrs[i]);
+        // Record the current function data container value for debugging
+        if (i < varCount) {
+            DoublePtr* doublePtr = dynamic_cast<DoublePtr*>(methodCallingOriginalPlaceHolderAddrs[i]);
+            if (doublePtr) {
+                debugPoint->addCurrentFuncVal(*(doublePtr->value));
+            }
+        }
 #endif
-        // Save the current value of the parameter in the called function (stack save)
-        variableStackCurrent[i] = *methodCalledOriginalPlaceHolderAddrs[i];
+        /*
+         * RECURSIVE SAFETY: Save the called function's parameter current value
+         * 
+         * Example: increment_recursive(level 2) call
+         * - dataContainerStackCurrent[0] saves whatever value n had before (garbage)
+         * - dataContainerStackCurrent[1] saves whatever value depth had before (garbage)
+         * - This is crucial for nested calls: level 1 -> level 2 -> level 3 -> level 4
+         * - Each level must restore its parameter state when unwinding
+         */
+        dataContainerStackCurrent[i]->copyDataContainerValue(methodCalledOriginalPlaceHolderAddrs[i]);
         
-        // Copy the argument value from calling context to called function parameter
-        *methodCalledOriginalPlaceHolderAddrs[i] = (*methodCallingOriginalPlaceHolderAddrs[i]);
-        
-        // Save the current value of the parameter variable for restoration after function execution
-        methodArgVariableCurrentVal[i] = *methodArgVariableAddr[i];
+        /*
+         * PARAMETER PASSING: Copy argument value to function parameter (CALL-BY-REFERENCE)
+         * 
+         * Example: increment_recursive(level 2) call
+         * - methodCallingOriginalPlaceHolderAddrs[0] contains value 7 (from level 1)
+         * - methodCallingOriginalPlaceHolderAddrs[1] contains value 1 (from level 1)
+         * - methodCalledOriginalPlaceHolderAddrs[0] is level 2's parameter n
+         * - methodCalledOriginalPlaceHolderAddrs[1] is level 2's parameter depth
+         * - After this: level 2's n = 7, depth = 1
+         * 
+         * CALL-BY-REFERENCE: Any modifications to n or depth in level 2 will be 
+         * visible to level 1 when control returns, because they point to the same memory.
+         */
+        methodCalledOriginalPlaceHolderAddrs[i]->copyDataContainerValue(methodCallingOriginalPlaceHolderAddrs[i]);
     }
 
 #ifdef DEBUG_BUILD
-    // Record array name mappings for debugging purposes
-    // This helps track which calling arrays correspond to which function parameters
-    for(auto it = arrayNameMethodMap.begin(); it != arrayNameMethodMap.end(); it++) {
+    // Record data container name mappings for debugging purposes
+    // This helps track which calling data containers correspond to which function parameters
+    for(auto it = dataContainerNameMethodMap.begin(); it != dataContainerNameMethodMap.end(); it++) {
         debugPoint->addArrayInFuncCall(it->first, it->second);
     }
     debugger->commitDebugPoint();
 #endif
 
     /*
-     * For local variables in the function (non-parameters):
-     * Save their current values so they can be restored after function execution.
-     * These variables start from index varCount (after the parameters).
+     * LOCAL VARIABLE BACKUP:
+     * 
+     * For all data containers in the function (both parameters and locals):
+     * Save their current DataContainerValue content so they can be restored after function execution.
+     * 
+     * RECURSIVE EXAMPLE:
+     * increment_recursive(level 2) has:
+     * - methodArgDataContainerAddr[0] = parameter 'n' (now = 7)
+     * - methodArgDataContainerAddr[1] = parameter 'depth' (now = 1)
+     * - methodArgDataContainerAddr[2] = local variable 'tmpVar' (could be garbage)
+     * 
+     * We save all values in methodArgDataContainerCurrentVal[0], [1], and [2]
+     * so when level 2 returns, level 1 can continue with clean state
      */
-    for(int i=varCount; i < totalVarCount; i++) {
-        methodArgVariableCurrentVal[i] = *methodArgVariableAddr[i];
+    int totalDataContainerCount = totalVarCount + totalArrCount;
+    for(int i = 0; i < totalDataContainerCount; i++) {
+        methodArgDataContainerCurrentVal[i]->copyDataContainerValue(methodArgDataContainerAddr[i]);
     }
 
-    // ==================== PHASE 2: ARRAY PARAMETER SETUP ====================
+    // ==================== PHASE 2: FUNCTION BODY EXECUTION ====================
     
     /*
-     * For each array parameter passed to the function:
-     * 1. Save the current array reference in the called function (for stack restoration)
-     * 2. Point the called function's parameter array to the calling function's argument array
-     * 3. Save the current array pointer for later restoration
+     * RECURSIVE EXECUTION DETAILS (STANDALONE FUNCTION CALLS):
+     * 
+     * increment_recursive(level 2) execution:
+     * 1. Checks: if depth <= 0 (false, since depth = 1)
+     * 2. Executes: n = n + 1 (n becomes 8)
+     * 3. Executes: tmpVar = depth - 1 (tmpVar becomes 0)
+     * 4. Prepares arguments for next call: n=8, tmpVar=0
+     * 5. Executes: increment_recursive(n, tmpVar) as STANDALONE FUNCTION CALL
+     * 6. This creates ANOTHER FunctionCommandRE::process() call for level 3
+     * 7. level 3 goes through its own complete PHASE 1-4 cycle
+     * 8. level 3 hits base case (depth=0) and returns without modification
+     * 9. level 2 continues after the function call (no return value to handle)
+     * 10. level 2 execution completes
+     * 
+     * CRITICAL CALL-BY-REFERENCE SEMANTICS:
+     * - When level 2 modifies n from 7 to 8, this change is visible to level 1
+     * - When level 3 executes with n=8, depth=0, it hits base case and doesn't modify n
+     * - So level 1 sees n=8 when level 2 returns
+     * 
+     * STANDALONE FUNCTION CALL CONSTRAINT:
+     * - increment_recursive() cannot be part of an expression like: result = increment_recursive(x, y)
+     * - It must be called as a standalone statement: increment_recursive(x, y);
+     * - Operations cannot be directly used as function arguments: increment_recursive(n, depth-1) is INVALID
+     * - Operations must be computed first: tmpVar = depth - 1; increment_recursive(n, tmpVar); is VALID
+     * - No return value is expected or processed
+     * 
+     * CRITICAL: Each recursive call has its own process() stack frame with:
+     * - Its own dataContainerStackCurrent array
+     * - Its own methodArgDataContainerCurrentVal backup
+     * - Complete isolation from other call levels
      */
-    for(int i = 0; i < arrCount; i++) {
-        // Save the current array reference in the called function (stack save)
-        arrayStackCurrent[i] = *methodCalledArrayPlaceHolderAddrs[i];
-        
-        // Point the called function's parameter array to the calling function's argument array
-        *methodCalledArrayPlaceHolderAddrs[i] = *methodCallingArrayPlaceHolderAddrs[i];
-        
-        // Save the current array pointer for restoration after function execution
-        methodArgArrayCurrentVal[i] = *methodArgArrayAddr[i];
-    }
-
-    /*
-     * For local arrays in the function (non-parameters):
-     * 1. Save their current array pointers
-     * 2. Allocate new memory for local arrays with their specified sizes
-     * These arrays start from index arrCount (after the parameters).
-     */
-    for(int i=arrCount;i< totalArrCount;i++) {
-        methodArgArrayCurrentVal[i] = *methodArgArrayAddr[i];
-        // Allocate new array for local array variables
-        *methodArgArrayAddr[i] = new double[methodArgArrayTotalSize[i]];
-    }
-
-    // ==================== PHASE 3: FUNCTION BODY EXECUTION ====================
     
     /*
      * Execute the function body by traversing the command chain.
@@ -202,320 +337,219 @@ void FunctionCommandRE::process() {
      */
     CommandRE* command = firstCommand;
     while(command != nullptr) {
+        /*
+         * RECURSIVE CALL HAPPENS HERE (STANDALONE):
+         * When command->get() encounters a function call like increment_recursive(n, tmpVar),
+         * it creates a NEW FunctionCommandRE object and calls ITS process() method.
+         * This creates a completely separate execution context while preserving
+         * the current one in our local variables.
+         * 
+         * IMPORTANT: The function call is executed as a standalone statement.
+         * No return value is expected or processed. All communication happens
+         * through call-by-reference parameter modification.
+         * 
+         * ARGUMENT CONSTRAINT: Only variables/arrays can be passed as arguments.
+         * Operations like (depth-1) must be computed in separate assignment statements first.
+         */
         command = command->get();  // Execute current command and get next command
     }
 
-    // ==================== PHASE 4: CONTEXT RESTORATION AND CLEANUP ====================
+    // ==================== PHASE 3: NON-PARAMETER DATA CONTAINER RESTORATION ====================
+    
+    /*
+     * RECURSIVE CLEANUP - PHASE 3:
+     * 
+     * After increment_recursive(level 2) finishes execution:
+     * 
+     * BEFORE PHASE 3:
+     * - level 2's parameter n = 8 (modified during execution)
+     * - level 2's parameter depth = 1 (unchanged)
+     * - level 2's local tmpVar = 0 (used for function argument)
+     * 
+     * DURING PHASE 3:
+     * - We restore ONLY local variables (tmpVar) to their pre-execution state
+     * - We DON'T restore parameters yet - they contain modified values for call-by-reference!
+     * 
+     * WHY SKIP PARAMETERS?
+     * The parameters contain the modified values that need to be visible to the calling function.
+     * In call-by-reference semantics, parameter modifications are the primary communication mechanism.
+     * We restore them last to ensure proper data flow.
+     */
+    
+    /*
+     * First, restore all non-parameter data containers to their pre-function-execution state.
+     * This ensures proper cleanup and prevents interference between recursive calls.
+     * 
+     * IMPORTANT: We only restore data containers that are NOT function parameters,
+     * because parameters need to retain their modified values for call-by-reference semantics.
+     */
+    for(int i = argSize; i < totalDataContainerCount; i++) {
+        /*
+         * RECURSIVE ISOLATION EXAMPLE:
+         * 
+         * increment_recursive(level 2) local variables:
+         * - methodArgDataContainerAddr[2] = tmpVar (currently = 0, used for function argument)
+         * - methodArgDataContainerCurrentVal[2] = saved pre-execution value of tmpVar (garbage)
+         * 
+         * After restoration:
+         * - tmpVar is reset to its pre-execution state
+         * - This prevents level 2's locals from corrupting level 1's execution
+         * - But parameters n and depth retain their modified values (8 and 1)
+         * 
+         * Restore non-parameter data container to its pre-function-execution value
+         * 
+         * FIELD EXPLANATION:
+         * - methodArgDataContainerAddr[i] points to the data container
+         * - methodArgDataContainerCurrentVal[i] contains the saved value from Phase 1
+         * - We start from argSize to skip parameter data containers (indices 0 to argSize-1)
+         */
+        methodArgDataContainerAddr[i]->copyDataContainerValue(methodArgDataContainerCurrentVal[i]);
+    }
+
+    // ==================== PHASE 4: PARAMETER RESTORATION AND CLEANUP ====================
+    
+    /*
+     * RECURSIVE UNWINDING - PHASE 4:
+     * 
+     * This is the CRITICAL phase for recursive functions with call-by-reference:
+     * 
+     * increment_recursive(level 2) returning to increment_recursive(level 1):
+     * 
+     * BEFORE PHASE 4:
+     * - level 2's parameter n = 8 (modified during execution)
+     * - level 2's parameter depth = 1 (unchanged)
+     * - level 1 expects to see these modified values through call-by-reference
+     * 
+     * DURING PHASE 4:
+     * - We restore level 2's parameters to their original state (before Phase 1)
+     * - But the calling function (level 1) has already received the modified values
+     * - This "rewinds" level 2's state as if the call never happened
+     * 
+     * CALL-BY-REFERENCE MECHANISM:
+     * - level 1's arguments and level 2's parameters point to the same memory
+     * - When level 2 modifies its parameters, level 1 sees the changes immediately
+     * - Restoring level 2's parameters doesn't affect level 1's view of the data
+     * 
+     * AFTER PHASE 4:
+     * - level 2's parameter state is restored (clean slate)
+     * - level 1 continues execution with modified argument values (n=8)
+     * - Stack frame is completely clean for next operation
+     */
     
     /*
      * CRITICAL: We must restore the calling context regardless of function execution outcome.
      * This is essential for recursive functions and proper stack management.
      * 
-     * Example scenario requiring restoration:
-     * func(a,b) {
-     *      c = a + 1
-     *      func(c,b)    // Recursive call modifies 'a'
-     *      d = a + 1    // Without restoration, 'a' would have value of 'c'
-     * }
+     * Restore the original DataContainerValue content that was overwritten during parameter setup.
+     * This happens AFTER non-parameter restoration so that call-by-reference semantics are preserved.
      */
-
-    // First, update our stack copies with the final values from the called function context
-    for(int i=0; i< varCount;i++) {
-        variableStackCurrent[i] = *methodCalledOriginalPlaceHolderAddrs[i];
-    }
-    for(int i=0; i< arrCount;i++) {
-        arrayStackCurrent[i] = *methodCalledArrayPlaceHolderAddrs[i];
-    }
-
-    // ==================== PHASE 5: VARIABLE RESTORATION ====================
-    
-    /*
-     * DETAILED VARIABLE RESTORATION EXPLANATION:
-     * 
-     * The restoration process is critical for maintaining proper function call semantics,
-     * especially for recursive functions. Here's what happens with concrete examples:
-     * 
-     * EXAMPLE CODE SCENARIO:
-     * ```
-     * func factorial(n) {
-     *     if (n <= 1) return 1;
-     *     temp = n - 1;
-     *     return n * factorial(temp);  // Recursive call
-     * }
-     * 
-     * main() {
-     *     x = 5;
-     *     result = factorial(x);  // Call with x=5
-     * }
-     * ```
-     * 
-     * FIELD CHANGES DURING EXECUTION:
-     * 
-     * 1. BEFORE CALL factorial(5):
-     *    - Main context: x = 5
-     *    - Function parameter 'n' is uninitialized
-     * 
-     * 2. DURING PARAMETER SETUP:
-     *    - methodCallingOriginalPlaceHolderAddrs[0] points to 'x' (value: 5)
-     *    - methodCalledOriginalPlaceHolderAddrs[0] points to 'n' (will receive 5)
-     *    - variableStackCurrent[0] saves old value of 'n' (for restoration)
-     *    - *methodCalledOriginalPlaceHolderAddrs[0] = 5 (n becomes 5)
-     * 
-     * 3. DURING FUNCTION EXECUTION:
-     *    - 'n' = 5, 'temp' gets allocated and set to 4
-     *    - When factorial(4) is called recursively:
-     *      - 'n' temporarily becomes 4 for the inner call
-     *      - Original 'n' (5) is saved in stack
-     * 
-     * 4. DURING RESTORATION (this phase):
-     *    - Inner call completes, 'n' needs to be restored to 5
-     *    - All local variables need to be reset to their pre-call state
-     */
-    
-    /*
-     * Variable Parameter Restoration Loop:
-     * For each variable parameter (i = 0 to varCount-1):
-     */
-    for(int i = 0; i < varCount; i++) {
+    for(int i = 0; i < argSize; i++) {
         /*
-         * Step 1: Restore the function parameter to its saved state
+         * RECURSIVE STACK UNWINDING WITH CALL-BY-REFERENCE:
          * 
-         * WHAT HAPPENS:
-         * - methodArgVariableAddr[i] points to the parameter variable in function scope
-         * - methodArgVariableCurrentVal[i] contains the saved value from before function execution
+         * Example: increment_recursive(level 3) returning to increment_recursive(level 2)
+         * - level 3's parameter n was set to 8 in Phase 1
+         * - level 3 hit base case and didn't modify n (still 8)
+         * - dataContainerStackCurrent[0] contains the original value n had before Phase 1 (garbage)
+         * - We restore n to that original value, effectively "undoing" the parameter setup
+         * - level 2 sees that its argument n is still 8 (the call-by-reference effect)
          * 
-         * EXAMPLE:
-         * If this is the inner factorial(4) call completing:
-         * - methodArgVariableAddr[0] points to 'n' (currently 4)
-         * - methodArgVariableCurrentVal[0] contains the saved value (4)
-         * - *methodArgVariableAddr[0] = 4 (restore 'n' to its pre-execution state)
+         * This ensures each recursive level is properly isolated and restored,
+         * while preserving call-by-reference semantics for parameter modifications.
+         * 
+         * Restore the original DataContainerValue content that the parameter contained
          */
-        *methodArgVariableAddr[i] = methodArgVariableCurrentVal[i];
-        
-        /*
-         * Step 2: Restore the calling context variable to its stack-saved value
-         * 
-         * WHAT HAPPENS:
-         * - methodCallingOriginalPlaceHolderAddrs[i] points to the argument variable in calling context
-         * - variableStackCurrent[i] contains the calling context's variable value from Phase 4
-         * 
-         * EXAMPLE:
-         * If this is factorial(4) completing and returning to factorial(5):
-         * - methodCallingOriginalPlaceHolderAddrs[0] points to 'temp' in factorial(5) context
-         * - variableStackCurrent[0] contains the value of 'temp' (4)
-         * - *methodCallingOriginalPlaceHolderAddrs[0] = 4 (restore 'temp' to 4)
-         * 
-         * This ensures that when factorial(4) returns, the factorial(5) context
-         * has 'temp' = 4 (not some corrupted value from the inner call)
-         */
-        *methodCallingOriginalPlaceHolderAddrs[i] = variableStackCurrent[i];
-    }
-    
-    /*
-     * Local Variable Restoration Loop:
-     * For local variables (non-parameters) (i = varCount to totalVarCount-1):
-     * 
-     * WHAT HAPPENS:
-     * These are variables declared within the function that are not parameters.
-     * 
-     * EXAMPLE:
-     * In factorial function: 'temp' is a local variable
-     * - Before function: temp = some_previous_value (or 0.0 if first time)
-     * - During function: temp = n - 1
-     * - After restoration: temp = some_previous_value
-     * 
-     * WHY NEEDED:
-     * If factorial(5) calls factorial(4), and factorial(4) has its own 'temp',
-     * we need to restore factorial(5)'s 'temp' when factorial(4) completes.
-     */
-    for(int i=varCount; i< totalVarCount; i++) {
-        /*
-         * Restore local variable to its pre-function-execution value
-         * 
-         * FIELD EXPLANATION:
-         * - methodArgVariableAddr[i] points to the local variable
-         * - methodArgVariableCurrentVal[i] contains the saved value from Phase 1
-         */
-        *methodArgVariableAddr[i] = methodArgVariableCurrentVal[i];
+        methodCalledOriginalPlaceHolderAddrs[i]->copyDataContainerValue(dataContainerStackCurrent[i]);
     }
 
-    // ==================== PHASE 6: ARRAY RESTORATION AND CLEANUP ====================
-    
     /*
-     * DETAILED ARRAY RESTORATION EXPLANATION:
+     * MEMORY CLEANUP:
      * 
-     * Arrays have more complex restoration because they involve pointer management
-     * and dynamic memory allocation.
+     * Clean up the stack management memory allocated for this function call.
+     * Each recursive call allocates its own dataContainerStackCurrent array,
+     * so each must clean up its own allocation.
      * 
-     * EXAMPLE CODE SCENARIO:
-     * ```
-     * func processArray(arr, size) {
-     *     localArr[10];  // Local array
-     *     // Process arrays...
-     *     processArray(arr, size-1);  // Recursive call
-     * }
-     * 
-     * main() {
-     *     mainArray[20] = {1,2,3,...};
-     *     processArray(mainArray, 20);
-     * }
-     * ```
-     * 
-     * FIELD CHANGES FOR ARRAYS:
-     * 
-     * 1. PARAMETER ARRAYS (i = 0 to arrCount-1):
-     *    - methodCallingArrayPlaceHolderAddrs[i] points to 'mainArray' in main()
-     *    - methodCalledArrayPlaceHolderAddrs[i] points to 'arr' parameter
-     *    - During function: 'arr' points to same memory as 'mainArray'
-     * 
-     * 2. LOCAL ARRAYS (i = arrCount to totalArrCount-1):
-     *    - methodArgArrayAddr[i] points to 'localArr' pointer
-     *    - During function: new memory allocated for 'localArr'
-     *    - After function: memory must be freed and pointer restored
+     * RECURSIVE SAFETY:
+     * This cleanup only affects the current call level.
+     * Other recursive levels have their own separate allocations.
      */
-    
-    /*
-     * Array Parameter Restoration Loop:
-     * For each array parameter (i = 0 to arrCount-1):
-     */
-    for(int i=0; i< arrCount; i++) {
-        /*
-         * Step 1: Restore the function parameter array to its saved pointer
-         * 
-         * WHAT HAPPENS:
-         * - methodArgArrayAddr[i] points to the array parameter's pointer in function scope
-         * - methodArgArrayCurrentVal[i] contains the saved array pointer from Phase 2
-         * 
-         * EXAMPLE:
-         * If processArray(subArray, 15) is completing:
-         * - methodArgArrayAddr[0] points to 'arr' parameter pointer
-         * - methodArgArrayCurrentVal[0] contains the saved pointer value
-         * - *methodArgArrayAddr[0] = saved_pointer (restore 'arr' pointer)
-         */
-        *methodArgArrayAddr[i] = methodArgArrayCurrentVal[i];
-        
-        /*
-         * Step 2: Restore the calling context array to its stack-saved reference
-         * 
-         * WHAT HAPPENS:
-         * - methodCallingArrayPlaceHolderAddrs[i] points to argument array in calling context
-         * - arrayStackCurrent[i] contains the calling context's array reference from Phase 4
-         * 
-         * EXAMPLE:
-         * When processArray(15) returns to processArray(20):
-         * - methodCallingArrayPlaceHolderAddrs[0] points to 'arr' in processArray(20)
-         * - arrayStackCurrent[0] contains the array reference from processArray(20)
-         * - *methodCallingArrayPlaceHolderAddrs[0] = array_ref (restore outer 'arr')
-         * 
-         * This ensures proper array reference restoration across recursive calls.
-         */
-        *methodCallingArrayPlaceHolderAddrs[i] = arrayStackCurrent[i];
+    for(int i = 0; i < argSize; i++) {
+        delete dataContainerStackCurrent[i];
     }
-    
+    delete[] dataContainerStackCurrent;
+
     /*
-     * Local Array Cleanup and Restoration Loop:
-     * For local arrays (non-parameters) (i = arrCount to totalArrCount-1):
+     * RECURSIVE EXECUTION COMPLETE:
      * 
-     * CRITICAL MEMORY MANAGEMENT:
-     * Local arrays are dynamically allocated during function execution and must be
-     * properly cleaned up to prevent memory leaks.
+     * At this point, the current function call is completely unwound:
+     * 1. All parameters are restored to pre-call state
+     * 2. All local variables are restored to pre-execution state  
+     * 3. All temporary memory is cleaned up
+     * 4. Control returns to the calling function (or main)
+     * 
+     * For our increment_recursive(x=5, depth=3) example:
+     * - increment_recursive(level 4) hits base case, returns to level 3
+     * - increment_recursive(level 3) incremented n from 7 to 8, returns to level 2  
+     * - increment_recursive(level 2) incremented n from 6 to 7, returns to level 1
+     * - increment_recursive(level 1) incremented n from 5 to 6, returns to main
+     * - Final result: x = 8 (original 5 + 3 increments through recursion)
+     * 
+     * Each level maintains perfect isolation through this process while preserving
+     * call-by-reference semantics for parameter modifications.
      */
-    for(int i=arrCount;i< totalArrCount;i++) {
-        /*
-         * Step 1: Free the dynamically allocated memory for local arrays
-         * 
-         * WHAT HAPPENS:
-         * - *methodArgArrayAddr[i] points to the dynamically allocated array memory
-         * - This memory was allocated in Phase 2 with: new double[methodArgArrayTotalSize[i]]
-         * - delete[] frees this memory to prevent memory leaks
-         * 
-         * EXAMPLE:
-         * - Local array 'localArr' was allocated with: new double[10]
-         * - *methodArgArrayAddr[1] points to this allocated memory
-         * - delete[] *methodArgArrayAddr[1] frees the 10*sizeof(double) bytes
-         * 
-         * MEMORY LEAK PREVENTION:
-         * Without this cleanup, each function call would leak memory equal to
-         * the size of all local arrays, leading to unbounded memory growth.
-         */
-        delete[] *methodArgArrayAddr[i];
-        
-        /*
-         * Step 2: Restore the array pointer to its pre-function-call value
-         * 
-         * WHAT HAPPENS:
-         * - methodArgArrayCurrentVal[i] contains the saved array pointer from Phase 2
-         * - This restores the array pointer to whatever it pointed to before function execution
-         * 
-         * EXAMPLE:
-         * - Before function: 'localArr' pointer = nullptr (or previous value)
-         * - During function: 'localArr' pointer = allocated_memory
-         * - After restoration: 'localArr' pointer = nullptr (restored)
-         * 
-         * RECURSIVE CALL SAFETY:
-         * This ensures that recursive calls don't interfere with each other's
-         * local array allocations and each call has clean local array state.
-         */
-        *methodArgArrayAddr[i] = methodArgArrayCurrentVal[i];
-    }
 
     // Function execution complete - calling context fully restored
 }
 
 void BuiltInFunctionsImpl::setFields(std::unordered_map<std::string, RuleEngineInputUnits *> *map) {
-    std::list<double *> methodArgVariableAddrList;
-    std::list<ArrayValue **> methodArgArrayAddrList;
+    std::list<DataContainerValue*> methodArgDataContainerAddrList;
 
     for (int i = 0; i < functionCommandInfo->argumentsSize; i++) {
-        auto arg = map->at(functionCommandInfo->arguments[i]);
-        if (dynamic_cast<ArrayRE *>(arg) != nullptr) {
+        AbstractDataContainer* arg = dynamic_cast<AbstractDataContainer*>(map->at(functionCommandInfo->arguments[i]));
+        methodArgDataContainerAddrList.push_back(arg->valPtr);
+        
+        if (dynamic_cast<ArrayRE *>(map->at(functionCommandInfo->arguments[i])) != nullptr) {
             arrCount++;
-            methodArgArrayAddrList.push_back(((ArrayRE *) arg)->getValPtr());
         } else {
             varCount++;
-            methodArgVariableAddrList.push_back(((DoublePtr *) arg)->getValPtrPtr());
         }
     }
 
-    methodArgVariableAddr = new double *[varCount];
-    methodArgArrayAddr = new ArrayValue **[arrCount];
+    methodArgDataContainerAddr = new DataContainerValue*[functionCommandInfo->argumentsSize];
 
-    for (int i = 0; i < varCount; i++) {
-        methodArgVariableAddr[i] = methodArgVariableAddrList.front();
-        methodArgVariableAddrList.pop_front();
-    }
-
-    for (int i = 0; i < arrCount; i++) {
-        methodArgArrayAddr[i] = methodArgArrayAddrList.front();
-        methodArgArrayAddrList.pop_front();
+    for (int i = 0; i < functionCommandInfo->argumentsSize; i++) {
+        methodArgDataContainerAddr[i] = methodArgDataContainerAddrList.front();
+        methodArgDataContainerAddrList.pop_front();
     }
 }
 
 void NINF::process() {
-    if(varCount == 1) {
-        *methodArgVariableAddr[0] = -std::numeric_limits<double>::infinity();
-    }
-
-    if(arrCount == 1)
-    {
-        ArrayValue** arrayValue = methodArgArrayAddr[0];
-        for(int i = 0; i < (*arrayValue)->totalSize; i++) {
-            (*arrayValue)->val[i] = -std::numeric_limits<double>::infinity();
+    if(arrCount > 0) {
+        // This is an array (ArrayDataContainerValue)
+        ArrayDataContainerValue* arrayPtr = static_cast<ArrayDataContainerValue*>(methodArgDataContainerAddr[0]);
+        ArrayValue* arrayValue = arrayPtr->arrayValue;
+        for(int j = 0; j < arrayValue->totalSize; j++) {
+            arrayValue->val[j] = -std::numeric_limits<double>::infinity();
         }
+    } else {
+        // This is a variable (DoublePtr)
+        DoublePtr* doublePtr = static_cast<DoublePtr*>(methodArgDataContainerAddr[0]);
+        *(doublePtr->value) = -std::numeric_limits<double>::infinity();
     }
 }
 
 void PINF::process() {
-    if(varCount == 1) {
-        *methodArgVariableAddr[0] = std::numeric_limits<double>::infinity();
-    }
-
-    if(arrCount == 1)
-    {
-        ArrayValue** arrayValue = methodArgArrayAddr[0];
-        for(int i = 0; i < (*arrayValue)->totalSize; i++) {
-            (*arrayValue)->val[i] = std::numeric_limits<double>::infinity();
+    if(arrCount > 0) {
+        // This is an array (ArrayDataContainerValue)
+        ArrayDataContainerValue* arrayPtr = static_cast<ArrayDataContainerValue*>(methodArgDataContainerAddr[0]);
+        ArrayValue* arrayValue = arrayPtr->arrayValue;
+        for(int j = 0; j < arrayValue->totalSize; j++) {
+            arrayValue->val[j] = std::numeric_limits<double>::infinity();
         }
+    } else {
+        // This is a variable (DoublePtr)
+        DoublePtr* doublePtr = static_cast<DoublePtr*>(methodArgDataContainerAddr[0]);
+        *(doublePtr->value) = std::numeric_limits<double>::infinity();
     }
 }
 
@@ -524,88 +558,102 @@ static std::mt19937 gen(rd()); // Mersenne Twister engine
 static std::uniform_real_distribution<> dis(0.0, 1.0);
 
 void RAND::process() {
-    if(varCount == 1) {
-        *methodArgVariableAddr[0] = dis(gen);
-    }
-
-    if(arrCount == 1)
-    {
-        ArrayValue** arrayValue = methodArgArrayAddr[0];
-        for(int i = 0; i < (*arrayValue)->totalSize; i++) {
-            (*arrayValue)->val[i] = dis(gen);
+    if(arrCount > 0) {
+        // This is an array (ArrayDataContainerValue)
+        ArrayDataContainerValue* arrayPtr = static_cast<ArrayDataContainerValue*>(methodArgDataContainerAddr[0]);
+        ArrayValue* arrayValue = arrayPtr->arrayValue;
+        for(int j = 0; j < arrayValue->totalSize; j++) {
+            arrayValue->val[j] = dis(gen);
         }
+    } else {
+        // This is a variable (DoublePtr)
+        DoublePtr* doublePtr = static_cast<DoublePtr*>(methodArgDataContainerAddr[0]);
+        *(doublePtr->value) = dis(gen);
     }
 }
 
 // All variable based built-in methods:
 void ABS::process() {
-    if(varCount == 1) {
-        *methodArgVariableAddr[0] = std::abs(*methodArgVariableAddr[0]);
+    if(functionCommandInfo->argumentsSize >= 1) {
+        DoublePtr* doublePtr = static_cast<DoublePtr*>(methodArgDataContainerAddr[0]);
+        *(doublePtr->value) = std::abs(*(doublePtr->value));
     }
 }
 
 void SIN::process() {
-    if(varCount == 1) {
-        *methodArgVariableAddr[0] = std::sin(*methodArgVariableAddr[0]);
+    if(functionCommandInfo->argumentsSize >= 1) {
+        DoublePtr* doublePtr = static_cast<DoublePtr*>(methodArgDataContainerAddr[0]);
+        *(doublePtr->value) = std::sin(*(doublePtr->value));
     }
 }
 
 void COS::process() {
-    if(varCount == 1) {
-        *methodArgVariableAddr[0] = std::cos(*methodArgVariableAddr[0]);
+    if(functionCommandInfo->argumentsSize >= 1) {
+        DoublePtr* doublePtr = static_cast<DoublePtr*>(methodArgDataContainerAddr[0]);
+        *(doublePtr->value) = std::cos(*(doublePtr->value));
     }
 }
 
 void TAN::process() {
-    if(varCount == 1) {
-        *methodArgVariableAddr[0] = std::tan(*methodArgVariableAddr[0]);
+    if(functionCommandInfo->argumentsSize >= 1) {
+        DoublePtr* doublePtr = static_cast<DoublePtr*>(methodArgDataContainerAddr[0]);
+        *(doublePtr->value) = std::tan(*(doublePtr->value));
     }
 }
 
 void ASIN::process() {
-    if(varCount == 1) {
-        *methodArgVariableAddr[0] = std::asin(*methodArgVariableAddr[0]);
+    if(functionCommandInfo->argumentsSize >= 1) {
+        DoublePtr* doublePtr = static_cast<DoublePtr*>(methodArgDataContainerAddr[0]);
+        *(doublePtr->value) = std::asin(*(doublePtr->value));
     }
 }
 
 void ACOS::process() {
-    if(varCount == 1) {
-        *methodArgVariableAddr[0] = std::acos(*methodArgVariableAddr[0]);
+    if(functionCommandInfo->argumentsSize >= 1) {
+        DoublePtr* doublePtr = static_cast<DoublePtr*>(methodArgDataContainerAddr[0]);
+        *(doublePtr->value) = std::acos(*(doublePtr->value));
     }
 }
 
 void ATAN::process() {
-    if(varCount == 1) {
-        *methodArgVariableAddr[0] = std::atan(*methodArgVariableAddr[0]);
+    if(functionCommandInfo->argumentsSize >= 1) {
+        DoublePtr* doublePtr = static_cast<DoublePtr*>(methodArgDataContainerAddr[0]);
+        *(doublePtr->value) = std::atan(*(doublePtr->value));
     }
 }
 
 void FLOOR::process() {
-    if(varCount == 1) {
-        *methodArgVariableAddr[0] = std::floor(*methodArgVariableAddr[0]);
+    if(functionCommandInfo->argumentsSize >= 1) {
+        DoublePtr* doublePtr = static_cast<DoublePtr*>(methodArgDataContainerAddr[0]);
+        *(doublePtr->value) = std::floor(*(doublePtr->value));
     }
 }
 
 void CEIL::process() {
-    if(varCount == 1) {
-        *methodArgVariableAddr[0] = std::ceil(*methodArgVariableAddr[0]);
+    if(functionCommandInfo->argumentsSize >= 1) {
+        DoublePtr* doublePtr = static_cast<DoublePtr*>(methodArgDataContainerAddr[0]);
+        *(doublePtr->value) = std::ceil(*(doublePtr->value));
     }
 }
 
 void EXP::process() {
-    if(varCount == 1) {
-        *methodArgVariableAddr[0] = std::exp(*methodArgVariableAddr[0]);
+    if(functionCommandInfo->argumentsSize >= 1) {
+        DoublePtr* doublePtr = static_cast<DoublePtr*>(methodArgDataContainerAddr[0]);
+        *(doublePtr->value) = std::exp(*(doublePtr->value));
     }
 }
 
 void SQRT::process() {
-    if(varCount == 1) {
-        *methodArgVariableAddr[0] = std::sqrt(*methodArgVariableAddr[0]);
+    if(functionCommandInfo->argumentsSize >= 1) {
+        DoublePtr* doublePtr = static_cast<DoublePtr*>(methodArgDataContainerAddr[0]);
+        *(doublePtr->value) = std::sqrt(*(doublePtr->value));
     }
 }
 
 void POW::process() {
-    if(varCount == 2) {
-        *methodArgVariableAddr[0] = std::pow(*methodArgVariableAddr[0], *methodArgVariableAddr[1]);
+    if(functionCommandInfo->argumentsSize >= 2) {
+        DoublePtr* doublePtr1 = static_cast<DoublePtr*>(methodArgDataContainerAddr[0]);
+        DoublePtr* doublePtr2 = static_cast<DoublePtr*>(methodArgDataContainerAddr[1]);
+        *(doublePtr1->value) = std::pow(*(doublePtr1->value), *(doublePtr2->value));
     }
 }

--- a/ramanujan-native/native/ruleEngineObject/RedefineArrayCommandRE.cpp
+++ b/ramanujan-native/native/ruleEngineObject/RedefineArrayCommandRE.cpp
@@ -8,13 +8,10 @@
 #include <json/json.h>
 
 void RedefineArrayCommandRE::process() {
-    if (!arrayValuePtr) {
-        return;
-    }
     // 1. Compute new dimensions using the class field dims
     for (int i = 0; i < dimsCount; ++i) {
         if (isVariableDimension[i] && dimensionVariableREs[i]) {
-            dims[i] = static_cast<int>(*dimensionVariableREs[i]->getValPtrPtr());
+            dims[i] = static_cast<int>(*((DoublePtr*)dimensionVariableREs[i]->getVal())->value);
         } else if (!isVariableDimension[i]) {
             dims[i] = staticDimensions[i];
         } else {
@@ -33,11 +30,11 @@ void RedefineArrayCommandRE::process() {
     // Optionally, copy dataType, name, etc. if needed
 
     // 3. Create a new ArrayValue with the new Array
-    ArrayValue* oldArrayValue = *arrayValuePtr;
+    ArrayValue* oldArrayValue = arrayValuePtr->arrayValue;
     ArrayValue* newArrayValue = new ArrayValue(newArray, arrayId);
 
     // 4. Update the pointer and delete the old ArrayValue
-    *arrayValuePtr = newArrayValue;
+    arrayValuePtr->arrayValue = newArrayValue;
     if (oldArrayValue) {
         oldArrayValue->destroy();
         delete oldArrayValue;

--- a/ramanujan-native/native/ruleEngineObject/RedefineArrayCommandRE.h
+++ b/ramanujan-native/native/ruleEngineObject/RedefineArrayCommandRE.h
@@ -17,13 +17,9 @@ public:
     std::vector<bool> isVariableDimension; // true if dimension is a variable, false if explicit integer
 
     // Pointer to the ArrayValue* of the target ArrayRE
-    ArrayValue **arrayValuePtr = nullptr;
+    ArrayDataContainerValue* arrayValuePtr;
 
     void destroy() override {
-        if (arrayValuePtr) {
-            delete *arrayValuePtr; // Assuming ownership of the ArrayValue
-            arrayValuePtr = nullptr;
-        }
     }
 
     void setFields(std::unordered_map<std::string, RuleEngineInputUnits*> *map) {
@@ -35,7 +31,7 @@ public:
         if (itArr != map->end()) {
             ArrayRE* arrayRE = dynamic_cast<ArrayRE*>(itArr->second);
             if (arrayRE) {
-                arrayValuePtr = arrayRE->getValPtr();
+                arrayValuePtr = (ArrayDataContainerValue*)(arrayRE->getVal());
             }
         }
         for (const auto& varId : newDimensions) {

--- a/ramanujan-native/native/ruleEngineObject/dataContainer/AbstractDataContainer.h
+++ b/ramanujan-native/native/ruleEngineObject/dataContainer/AbstractDataContainer.h
@@ -11,12 +11,27 @@ class ArrayValue;
 
 class AbstractDataContainer {
 public:
-    DataContainerValue** valPtr;
+    DataContainerValue* valPtr;
 
-    virtual std::string getId() = 0;
+    /*
+     * To be transferred in function stack calls. For example,
+     * def func(a,b){}
+     *
+     * function call:
+     * func(x,y);
+     *
+     * Here, a,b,x,y are all of type AbstractDataContainer.
+     * When func is called, we need to set a,b's valPtr to point to x,y's valPtr.
+     * This is done using valPtrPtr.
+     *
+     * *a.valPtrPtr = &x.valPtr;
+     */
+    DataContainerValue** valPtrPtr = nullptr;
 
-    virtual DataContainerValue* getVal() = 0;
-    virtual void setVal(DataContainerValue* val) = 0;
+    DataContainerValue* getVal()
+    {
+        return valPtr;
+    };
 };
 
 #endif // ABSTRACTDATACONTAINER_H

--- a/ramanujan-native/native/ruleEngineObject/dataContainer/ArrayRE.h
+++ b/ramanujan-native/native/ruleEngineObject/dataContainer/ArrayRE.h
@@ -18,16 +18,15 @@ private:
     std::string dataType;
 
 public:
-    ArrayValue* arrayValue;
+    ArrayDataContainerValue arrayValue;
     std::string name, frameCount;
 
-    ArrayRE(Array *array) {
+    ArrayRE(Array *array) : arrayValue(new ArrayValue(array, array->id)){
         this->array = array;
 
         this->id = array->id;
         this->name = array->name;;
-        this->arrayValue = new ArrayValue(array, this->id);
-        this->valPtr = reinterpret_cast<DataContainerValue **>(&arrayValue);
+        this->valPtr = &arrayValue;
         this->frameCount = array->frameCount;
     }
 
@@ -40,24 +39,6 @@ public:
     }
 
     void destroy() {
-        if(arrayValue != nullptr)
-        delete arrayValue;
-    }
-
-    std::string getId() override {
-        return std::string();
-    }
-
-    virtual DataContainerValue* getVal() {
-        return arrayValue;
-    }
-
-    ArrayValue** getValPtr() {
-        return &arrayValue;
-    }
-
-    virtual void setVal(DataContainerValue *val) {
-        arrayValue = (ArrayValue*)(val);
     }
 };
 #endif //NATIVE_ARRAYRE_H

--- a/ramanujan-native/native/ruleEngineObject/dataContainer/DataContainerValue.h
+++ b/ramanujan-native/native/ruleEngineObject/dataContainer/DataContainerValue.h
@@ -5,6 +5,8 @@
 #ifndef NATIVE_DATACONTAINERVALUE_H
 #define NATIVE_DATACONTAINERVALUE_H
 class DataContainerValue {
-
+public:
+    virtual ~DataContainerValue() = default;
+    virtual void copyDataContainerValue(DataContainerValue* toBeCopied) = 0;
 };
 #endif //NATIVE_DATACONTAINERVALUE_H

--- a/ramanujan-native/native/ruleEngineObject/dataContainer/array/ArrayValue.h
+++ b/ramanujan-native/native/ruleEngineObject/dataContainer/array/ArrayValue.h
@@ -17,7 +17,7 @@
 
 class AbstractDataContainer;
 
-class ArrayValue : public DataContainerValue {
+class ArrayValue {
 private:
     Array* array = nullptr;
 
@@ -114,6 +114,30 @@ public:
             sizeAtIndex[index - 1] = result;
         }
         return result;
+    }
+};
+
+class ArrayDataContainerValue : public DataContainerValue
+{
+public:
+    ArrayValue * arrayValue;
+
+    ArrayDataContainerValue() = default;
+
+    ArrayDataContainerValue(ArrayValue* arrayValueIn)
+    {
+        arrayValue = arrayValueIn;
+    }
+
+    void setArrayValue(ArrayValue* arrayValueIn) {
+        if(arrayValue)
+            delete arrayValue;
+        arrayValue = arrayValueIn;
+    }
+
+    void copyDataContainerValue(DataContainerValue* toBeCopied) override
+    {
+        arrayValue = ((ArrayDataContainerValue*) toBeCopied)->arrayValue;
     }
 };
 


### PR DESCRIPTION
This pull request refactors the handling of variable pointers in condition and operation classes, replacing raw `double*` pointers with a `DoublePtr*` wrapper. This change is applied consistently across comparison (e.g., greater than, less than, equal to, not equal to) and arithmetic (e.g., addition) operation classes, as well as their cached variants. The update improves type safety and encapsulation when working with variable references throughout the codebase.

### Pointer Wrapping and Refactoring

* Replaced all usage of raw `double*` pointers with `DoublePtr*` in condition function classes (`GreaterThanImpl`, `GreaterThanEqualToImpl`, `LessThanImpl`, `LessThanEqualToImpl`, `IsEqualImpl`, `NotEqualImpl`) and their cached variants. This includes updating constructor signatures, member variables, and logic to dereference `.value` from `DoublePtr` instead of using the pointer directly. [[1]](diffhunk://#diff-7aea9b3ffaa945467203fb8b8d6c43411605f603086ad3156d6dba48b22c6d25L33-R79) [[2]](diffhunk://#diff-7aea9b3ffaa945467203fb8b8d6c43411605f603086ad3156d6dba48b22c6d25L90-R91) [[3]](diffhunk://#diff-7222cdf407d0f284845b9bd262553d9b935a196b5288f7f0111b955c03a3bcb5L27-R73) [[4]](diffhunk://#diff-7222cdf407d0f284845b9bd262553d9b935a196b5288f7f0111b955c03a3bcb5L84-R85) [[5]](diffhunk://#diff-4ffa3470a0983d0a490d37f8d0ae588c799fcc7a99808425377c77673208ac5eL30-R75) [[6]](diffhunk://#diff-4ffa3470a0983d0a490d37f8d0ae588c799fcc7a99808425377c77673208ac5eL88-R89) [[7]](diffhunk://#diff-f6edbcd63bb047d263352c62f4a83d18c5e0491492bb687ee467fe350835d199L30-R76) [[8]](diffhunk://#diff-f6edbcd63bb047d263352c62f4a83d18c5e0491492bb687ee467fe350835d199L87-R88) [[9]](diffhunk://#diff-18ec9b57d119cf8ff923ac67618ad58163c2c677420f99c9a1cd908ae25ea114L31-R76) [[10]](diffhunk://#diff-18ec9b57d119cf8ff923ac67618ad58163c2c677420f99c9a1cd908ae25ea114L88-R89) [[11]](diffhunk://#diff-442910972261a49870230408a8963255254eb8a720a57063d16ce00dabd819d8L32-R77) [[12]](diffhunk://#diff-442910972261a49870230408a8963255254eb8a720a57063d16ce00dabd819d8L88-R89)

* Updated arithmetic operation classes, specifically addition (`AddImpl.h`), to use `DoublePtr*` instead of `double*` for variable references in both member variables and method logic.

### Data Structure and Type Adjustments

* Modified the casting and access pattern for array values in `Processor.cpp` to use the `ArrayDataContainerValue` wrapper when retrieving `ArrayValue`, ensuring compatibility with the new pointer management approach.