### PR TITLE
readme improvement; opencl api ramanujan header

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -64,5 +64,22 @@ runtime, OpenCL backend) is independent work and is not derived from Newton.
 
 ---
 
+## Android OpenCL support
+
+Ramanujan's Android native runtime uses OpenCL API definitions from the
+[Khronos OpenCL-Headers](https://github.com/KhronosGroup/OpenCL-Headers)
+project and dynamically loads the OpenCL implementation provided by the
+device's GPU vendor.
+
+Our thanks to the Khronos Group, the OpenCL community, and Android GPU vendors
+for maintaining the specifications, headers, and device implementations that
+make portable on-device GPU computation possible.
+
+The runtime loader in
+[`ramanujan-native/native/opencl_loader.h`](ramanujan-native/native/opencl_loader.h)
+uses the OpenCL API definitions.
+
+---
+
 For runtime/build dependencies of the Ramanujan platform itself, see
 [`THIRD_PARTY_LICENSES.md`](THIRD_PARTY_LICENSES.md).

--- a/README.md
+++ b/README.md
@@ -1006,7 +1006,7 @@ def p2g_GPU_1(positions, g_mass, g_vel, params, gid):
 - Each unique kernel source is **compiled and cached** on first invocation; repeated calls to the same GPU function reuse the cached `cl_kernel`.
 - Data is staged `double → float` before upload and `float → double` after read-back (OpenCL kernels operate on `float`).
 - If OpenCL initialisation fails at runtime a diagnostic is printed to `stderr` and execution returns immediately.
-- The `GPU_ENABLED` macro must be set at compile time (via `-DENABLE_GPU=ON`). Builds without it contain **no OpenCL code** and have no OpenCL runtime dependency.
+- The `GPU_ENABLED` macro must be set at compile time (via `-DGPU_ENABLED=ON`). Builds without it contain **no OpenCL code** and have no OpenCL runtime dependency.
 
 ## Explicit GPU synchronisation — `GPU_SYNC`
 
@@ -1285,6 +1285,219 @@ The goal is to make Python code seamlessly executable on the distributed Ramanuj
       C code without an additional step of compilation. [far future]
 2. Dependency registry for the libraries. All major functionalities as given by Maven, NPM, etc. should be available.
 
+# Contributor quick start: Monte Carlo on a computer and Android phone
+
+The steps below build the developer console and native runtime from source, run
+the Monte Carlo pi example locally, and then use an Android phone as a homelab
+worker.
+
+## Prerequisites
+
+- Git, Python 3.12 or newer, and `pip`
+- JDK 17 with `JAVA_HOME` set
+- Maven 3.9 or newer
+- CMake 3.27 or newer and a C++ compiler
+- Android Studio with Android SDK 34 and NDK 26.1.10909125 for the phone build
+- macOS, or Ubuntu with `libjsoncpp-dev`, `ocl-icd-opencl-dev`, and
+    `opencl-headers` installed
+
+On Ubuntu, install the native packages with:
+
+```sh
+sudo apt update
+sudo apt install build-essential cmake libjsoncpp-dev ocl-icd-opencl-dev opencl-headers
+```
+
+## Clone the repository and create a workspace
+
+The Ramanujan workspace is a separate directory for runtime binaries. It is not
+the Git repository. Create both directories and set `RAMANUJAN_WS` to the
+workspace's absolute path:
+
+```sh
+git clone https://github.com/Ramanujan-Computing/Ramanujan.git
+cd Ramanujan
+
+mkdir -p "$HOME/ramanujan-ws"
+export RAMANUJAN_WS="$HOME/ramanujan-ws"
+```
+
+Add the `export` command to `~/.zshrc` or `~/.bashrc` to keep it across terminal
+sessions.
+
+## Build the Java modules and developer console
+
+Install the Python translation dependency, then build the Maven modules in
+dependency order:
+
+```sh
+python3 -m pip install ast2json
+chmod +x projectBuilder.sh
+./projectBuilder.sh
+```
+
+The final Java artifact is
+`developer-console/target/developer-console-1.0-SNAPSHOT-fat.jar`. Copy it
+directly into the workspace:
+
+```sh
+cp developer-console/target/developer-console-1.0-SNAPSHOT-fat.jar "$RAMANUJAN_WS/"
+```
+
+## Build and install the desktop native binary
+
+`projectBuilder.sh` creates a standard native build. To configure it explicitly
+with OpenCL GPU support and release optimizations, run:
+
+```sh
+cmake -S ramanujan-native/native -B ramanujan-native/native/build \
+    -DGPU_ENABLED=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build ramanujan-native/native/build --target native_lib
+```
+
+Copy the library into the workspace beside the developer-console JAR:
+
+```sh
+# macOS
+cp ramanujan-native/native/build/libnative.dylib "$RAMANUJAN_WS/"
+
+# Ubuntu
+cp ramanujan-native/native/build/libnative.so "$RAMANUJAN_WS/"
+```
+
+The workspace must now contain:
+
+```text
+ramanujan-ws/
+├── developer-console-1.0-SNAPSHOT-fat.jar
+└── libnative.dylib    # macOS
+        libnative.so       # Ubuntu, instead of libnative.dylib
+```
+
+Install the `rj` command by adding this alias to `~/.zshrc` or `~/.bashrc`, then
+reload that file:
+
+```sh
+alias rj='java -jar "$RAMANUJAN_WS/developer-console-1.0-SNAPSHOT-fat.jar"'
+source ~/.zshrc   # use ~/.bashrc when running Bash
+```
+
+Run `rj` in a new terminal to verify that the command and workspace environment
+are available.
+
+Alternatively, `./install_ramanujan.sh` prompts for a workspace, downloads a
+released developer-console JAR, and installs the same alias. When developing
+from source, overwrite that downloaded JAR with the one built above.
+
+## Run the Monte Carlo simulation locally
+
+Use two terminals from the repository root.
+
+In terminal 1, start the homelab server:
+
+```sh
+rj homelab
+```
+
+Wait for `HOMELAB_READY`. In terminal 2, start a local native worker:
+
+```sh
+rj worker http://localhost:8888 4
+```
+
+In the interactive prompt in terminal 1, submit the simulation and inspect its
+result:
+
+```text
+run ramanujan-test-codes/monte_carlo/monte_carlo_pi.py
+var estimated_pi
+var total_points_in_circle
+```
+
+Wait for `KERNEL_DONE` before entering the `var` commands. `estimated_pi` should
+be close to `3.14159`; its exact value changes on every run.
+
+## Build the Android native binary
+
+Android Studio installs the NDK under the Android SDK. Find the installed NDK
+path in Android Studio under **Settings > Languages & Frameworks > Android SDK >
+SDK Tools**, or list the versions from a terminal:
+
+```sh
+ls "$HOME/Library/Android/sdk/ndk"   # macOS default
+ls "$HOME/Android/Sdk/ndk"          # Linux default
+```
+
+From the repository root, pass the selected NDK directory to
+`compileAndroid.sh`:
+
+```sh
+cd ramanujan-native/native
+chmod +x compileAndroid.sh
+./compileAndroid.sh "$HOME/Library/Android/sdk/ndk/26.1.10909125"
+cd ../..
+```
+
+On Linux, replace the argument with the corresponding path under
+`$HOME/Android/Sdk/ndk`. The script builds the `arm64-v8a` release library at
+`ramanujan-native/native/build/arm64-v8a/libnative.so` and automatically copies
+it to `androidapp/app/src/main/jniLibs/arm64-v8a/libnative.so`, where Gradle
+packages it into the APK.
+
+## Build and run the Android app
+
+The Android app depends on `ramanujan-device-common` from the local Maven
+repository. It was installed by `projectBuilder.sh`; if only the app is being
+rebuilt, refresh it with:
+
+```sh
+mvn -f commons/pom.xml clean install
+mvn -f rule-engine/pom.xml clean install
+mvn -f ramanujan-device-common/pom.xml clean install
+```
+
+Then:
+
+1. Open the `androidapp` directory in Android Studio.
+2. Allow Gradle sync to finish and accept any requested SDK installation.
+3. Connect an arm64 Android phone with Developer options and USB debugging
+     enabled, then accept the debugging prompt on the phone.
+4. Select the phone as the run target and click **Run app**.
+
+To build an APK without Android Studio, run:
+
+```sh
+cd androidapp
+./gradlew assembleDebug
+```
+
+The APK is written to `androidapp/app/build/outputs/apk/debug/app-debug.apk`.
+
+## Run Monte Carlo on the phone
+
+Connect the computer and phone to the same local network. Start `rj homelab` on
+the computer and note the non-`localhost` URL printed as `HOMELAB_ADDRESS`, for
+example `http://192.168.1.42:8888`.
+
+Open the Android app and enter the complete URL after `HOMELAB_ADDRESS` in
+**Server URL**, including `http://` and port `8888`. For example, if the server
+prints `HOMELAB_ADDRESS http://192.168.1.42:8888`, enter exactly
+`http://192.168.1.42:8888`, then tap **Start Workers**. Do not use `localhost`
+in the app because that refers to the phone itself. Allow notification
+permission when prompted so the foreground worker can continue running.
+
+Submit the same commands in the computer's homelab terminal:
+
+```text
+run ramanujan-test-codes/monte_carlo/monte_carlo_pi.py
+var estimated_pi
+```
+
+Stop the desktop `rj worker` first when you want to confirm that the phone is
+the device executing the simulation. If the phone cannot connect, verify that
+both devices are on the same Wi-Fi network and that the computer's firewall
+allows inbound TCP connections on port `8888`.
+
 # Build and usage Strategy:
 ## Build:
 Use `mvn clean install`. Following is the dependency hierarchy:
@@ -1320,11 +1533,11 @@ cmake --build .
 cd ramanujan-native/native
 mkdir build-gpu
 cd build-gpu
-cmake -DENABLE_GPU=ON ..
+cmake -DGPU_ENABLED=ON -DCMAKE_BUILD_TYPE=Release ..
 cmake --build .
 ```
-Passing `-DENABLE_GPU=ON` sets the `GPU_ENABLED` preprocessor macro, links OpenCL, and activates
-OpenCL kernel dispatch for `_GPU`-suffixed functions. Standard builds (`-DENABLE_GPU=OFF`, the
+Passing `-DGPU_ENABLED=ON` sets the `GPU_ENABLED` preprocessor macro, links OpenCL, and activates
+OpenCL kernel dispatch for `_GPU`-suffixed functions. Standard builds (`-DGPU_ENABLED=OFF`, the
 default) compile no OpenCL code and have no dependency on any OpenCL runtime.
 ### Docker build:
 Dockerfile is provided to containerize all the necessary services.
@@ -1385,7 +1598,6 @@ chmod +x install_ramanujan.sh
 
 - The script will prompt you for a workspace path and set the `RAMANUJAN_WS` environment variable.
 - It will download the latest developer console JAR to your workspace.
-- It will check for and install `libjsoncpp` if needed.
 - It will add an alias `rj` to your shell profile for easy usage.
 
 **After installation, restart your terminal or run:**

--- a/ramanujan-native/native/opencl_loader.h
+++ b/ramanujan-native/native/opencl_loader.h
@@ -1,0 +1,207 @@
+#pragma once
+// ----------------------------------------------------------------------------
+// Android-only runtime OpenCL loader.
+//
+// On Android the Khronos ICD loader finds OpenCL via /etc/OpenCL/vendors/*.icd
+// files, which do not exist on Android.  The vendor's libOpenCL.so lives at a
+// device-specific path (e.g. /system/vendor/lib64/libOpenCL.so).  We must
+// dlopen it explicitly.
+//
+// Usage
+//   Before calling any cl* function, call openclLoad().
+//   It is idempotent and thread-safe; call it once from GpuContext::init().
+//   Returns true if the library was found and all symbols resolved.
+//
+// The AndroidManifest must also declare:
+//   <uses-native-library android:name="libOpenCL.so" android:required="false"/>
+// so the system linker namespace grants us access to the vendor library.
+// ----------------------------------------------------------------------------
+
+#ifdef __ANDROID__
+#include <android/log.h>
+#include <dlfcn.h>
+
+#define _RJ_OCL_TAG "RamanujanOpenCL"
+#define _RJ_OCL_LOGI(...)                                                      \
+  __android_log_print(ANDROID_LOG_INFO, _RJ_OCL_TAG, __VA_ARGS__)
+#define _RJ_OCL_LOGE(...)                                                      \
+  __android_log_print(ANDROID_LOG_ERROR, _RJ_OCL_TAG, __VA_ARGS__)
+
+// ── function pointer types ────────────────────────────────────────────────
+typedef cl_int (*PFN_clGetPlatformIDs)(cl_uint, cl_platform_id *, cl_uint *);
+typedef cl_int (*PFN_clGetDeviceIDs)(cl_platform_id, cl_device_type, cl_uint,
+                                     cl_device_id *, cl_uint *);
+typedef cl_context (*PFN_clCreateContext)(
+    const cl_context_properties *, cl_uint, const cl_device_id *,
+    void (*)(const char *, const void *, size_t, void *), void *, cl_int *);
+typedef cl_command_queue (*PFN_clCreateCommandQueue)(
+    cl_context, cl_device_id, cl_command_queue_properties, cl_int *);
+typedef cl_command_queue (*PFN_clCreateCommandQueueWithProperties)(
+    cl_context, cl_device_id, const cl_queue_properties *, cl_int *);
+typedef cl_int (*PFN_clGetDeviceInfo)(cl_device_id, cl_device_info, size_t,
+                                      void *, size_t *);
+typedef cl_int (*PFN_clGetPlatformInfo)(cl_platform_id, cl_platform_info,
+                                        size_t, void *, size_t *);
+typedef cl_mem (*PFN_clCreateBuffer)(cl_context, cl_mem_flags, size_t, void *,
+                                     cl_int *);
+typedef cl_int (*PFN_clEnqueueWriteBuffer)(cl_command_queue, cl_mem, cl_bool,
+                                           size_t, size_t, const void *,
+                                           cl_uint, const cl_event *,
+                                           cl_event *);
+typedef cl_int (*PFN_clEnqueueReadBuffer)(cl_command_queue, cl_mem, cl_bool,
+                                          size_t, size_t, void *, cl_uint,
+                                          const cl_event *, cl_event *);
+typedef cl_program (*PFN_clCreateProgramWithSource)(cl_context, cl_uint,
+                                                    const char **,
+                                                    const size_t *, cl_int *);
+typedef cl_int (*PFN_clBuildProgram)(cl_program, cl_uint, const cl_device_id *,
+                                     const char *, void (*)(cl_program, void *),
+                                     void *);
+typedef cl_int (*PFN_clGetProgramBuildInfo)(cl_program, cl_device_id,
+                                            cl_program_build_info, size_t,
+                                            void *, size_t *);
+typedef cl_kernel (*PFN_clCreateKernel)(cl_program, const char *, cl_int *);
+typedef cl_int (*PFN_clSetKernelArg)(cl_kernel, cl_uint, size_t, const void *);
+typedef cl_int (*PFN_clGetKernelWorkGroupInfo)(cl_kernel, cl_device_id,
+                                               cl_kernel_work_group_info,
+                                               size_t, void *, size_t *);
+typedef cl_int (*PFN_clEnqueueNDRangeKernel)(cl_command_queue, cl_kernel,
+                                             cl_uint, const size_t *,
+                                             const size_t *, const size_t *,
+                                             cl_uint, const cl_event *,
+                                             cl_event *);
+typedef cl_int (*PFN_clFinish)(cl_command_queue);
+typedef cl_int (*PFN_clFlush)(cl_command_queue);
+typedef cl_int (*PFN_clReleaseMemObject)(cl_mem);
+typedef cl_int (*PFN_clReleaseProgram)(cl_program);
+typedef cl_int (*PFN_clReleaseKernel)(cl_kernel);
+typedef cl_int (*PFN_clReleaseCommandQueue)(cl_command_queue);
+typedef cl_int (*PFN_clReleaseContext)(cl_context);
+
+// ── storage ───────────────────────────────────────────────────────────────
+namespace rj_ocl {
+static void *g_lib = nullptr;
+
+static PFN_clGetPlatformIDs pfn_clGetPlatformIDs = nullptr;
+static PFN_clGetDeviceIDs pfn_clGetDeviceIDs = nullptr;
+static PFN_clCreateContext pfn_clCreateContext = nullptr;
+static PFN_clCreateCommandQueue pfn_clCreateCommandQueue = nullptr;
+static PFN_clCreateCommandQueueWithProperties
+    pfn_clCreateCommandQueueWithProperties = nullptr;
+static PFN_clGetDeviceInfo pfn_clGetDeviceInfo = nullptr;
+static PFN_clGetPlatformInfo pfn_clGetPlatformInfo = nullptr;
+static PFN_clCreateBuffer pfn_clCreateBuffer = nullptr;
+static PFN_clEnqueueWriteBuffer pfn_clEnqueueWriteBuffer = nullptr;
+static PFN_clEnqueueReadBuffer pfn_clEnqueueReadBuffer = nullptr;
+static PFN_clCreateProgramWithSource pfn_clCreateProgramWithSource = nullptr;
+static PFN_clBuildProgram pfn_clBuildProgram = nullptr;
+static PFN_clGetProgramBuildInfo pfn_clGetProgramBuildInfo = nullptr;
+static PFN_clCreateKernel pfn_clCreateKernel = nullptr;
+static PFN_clSetKernelArg pfn_clSetKernelArg = nullptr;
+static PFN_clGetKernelWorkGroupInfo pfn_clGetKernelWorkGroupInfo = nullptr;
+static PFN_clEnqueueNDRangeKernel pfn_clEnqueueNDRangeKernel = nullptr;
+static PFN_clFinish pfn_clFinish = nullptr;
+static PFN_clFlush pfn_clFlush = nullptr;
+static PFN_clReleaseMemObject pfn_clReleaseMemObject = nullptr;
+static PFN_clReleaseProgram pfn_clReleaseProgram = nullptr;
+static PFN_clReleaseKernel pfn_clReleaseKernel = nullptr;
+static PFN_clReleaseCommandQueue pfn_clReleaseCommandQueue = nullptr;
+static PFN_clReleaseContext pfn_clReleaseContext = nullptr;
+
+#define _RJ_LOAD(name)                                                         \
+  pfn_##name = reinterpret_cast<PFN_##name>(dlsym(g_lib, #name));              \
+  if (!pfn_##name) {                                                           \
+    _RJ_OCL_LOGE("dlsym failed: " #name);                                      \
+    return false;                                                              \
+  }
+
+static bool load() {
+  if (g_lib)
+    return true;
+
+  // Try common vendor paths; the manifest <uses-native-library> tag makes
+  // "libOpenCL.so" resolvable via the system linker namespace on Android 10+.
+  const char *candidates[] = {
+      "libOpenCL.so", "/system/vendor/lib64/libOpenCL.so",
+      "/system/lib64/libOpenCL.so", "/vendor/lib64/libOpenCL.so", nullptr};
+  for (int i = 0; candidates[i]; i++) {
+    g_lib = dlopen(candidates[i], RTLD_NOW | RTLD_GLOBAL);
+    if (g_lib) {
+      _RJ_OCL_LOGI("Loaded OpenCL from: %s", candidates[i]);
+      break;
+    }
+  }
+  if (!g_lib) {
+    _RJ_OCL_LOGE("Could not load libOpenCL.so: %s", dlerror());
+    return false;
+  }
+
+  _RJ_LOAD(clGetPlatformIDs)
+  _RJ_LOAD(clGetDeviceIDs)
+  _RJ_LOAD(clCreateContext)
+  _RJ_LOAD(clCreateCommandQueue)
+  // clCreateCommandQueueWithProperties is CL 2.0+; not all devices support it.
+  // Resolve best-effort — GpuContext::init() falls back to clCreateCommandQueue
+  // when this pointer is null.
+  pfn_clCreateCommandQueueWithProperties =
+      reinterpret_cast<PFN_clCreateCommandQueueWithProperties>(
+          dlsym(g_lib, "clCreateCommandQueueWithProperties"));
+  // (no fatal error if absent)
+  _RJ_LOAD(clGetDeviceInfo)
+  _RJ_LOAD(clGetPlatformInfo)
+  _RJ_LOAD(clCreateBuffer)
+  _RJ_LOAD(clEnqueueWriteBuffer)
+  _RJ_LOAD(clEnqueueReadBuffer)
+  _RJ_LOAD(clCreateProgramWithSource)
+  _RJ_LOAD(clBuildProgram)
+  _RJ_LOAD(clGetProgramBuildInfo)
+  _RJ_LOAD(clCreateKernel)
+  _RJ_LOAD(clSetKernelArg)
+  _RJ_LOAD(clGetKernelWorkGroupInfo)
+  _RJ_LOAD(clEnqueueNDRangeKernel)
+  _RJ_LOAD(clFinish)
+  _RJ_LOAD(clFlush)
+  _RJ_LOAD(clReleaseMemObject)
+  _RJ_LOAD(clReleaseProgram)
+  _RJ_LOAD(clReleaseKernel)
+  _RJ_LOAD(clReleaseCommandQueue)
+  _RJ_LOAD(clReleaseContext)
+
+  _RJ_OCL_LOGI("OpenCL symbols resolved successfully");
+  return true;
+}
+} // namespace rj_ocl
+
+// Redirect bare cl* names to the loaded function pointers
+#define clGetPlatformIDs rj_ocl::pfn_clGetPlatformIDs
+#define clGetDeviceIDs rj_ocl::pfn_clGetDeviceIDs
+#define clCreateContext rj_ocl::pfn_clCreateContext
+#define clCreateCommandQueue rj_ocl::pfn_clCreateCommandQueue
+#define clCreateCommandQueueWithProperties                                     \
+  rj_ocl::pfn_clCreateCommandQueueWithProperties
+#define clGetDeviceInfo rj_ocl::pfn_clGetDeviceInfo
+#define clGetPlatformInfo rj_ocl::pfn_clGetPlatformInfo
+#define clCreateBuffer rj_ocl::pfn_clCreateBuffer
+#define clEnqueueWriteBuffer rj_ocl::pfn_clEnqueueWriteBuffer
+#define clEnqueueReadBuffer rj_ocl::pfn_clEnqueueReadBuffer
+#define clCreateProgramWithSource rj_ocl::pfn_clCreateProgramWithSource
+#define clBuildProgram rj_ocl::pfn_clBuildProgram
+#define clGetProgramBuildInfo rj_ocl::pfn_clGetProgramBuildInfo
+#define clCreateKernel rj_ocl::pfn_clCreateKernel
+#define clSetKernelArg rj_ocl::pfn_clSetKernelArg
+#define clGetKernelWorkGroupInfo rj_ocl::pfn_clGetKernelWorkGroupInfo
+#define clEnqueueNDRangeKernel rj_ocl::pfn_clEnqueueNDRangeKernel
+#define clFinish rj_ocl::pfn_clFinish
+#define clFlush rj_ocl::pfn_clFlush
+#define clReleaseMemObject rj_ocl::pfn_clReleaseMemObject
+#define clReleaseProgram rj_ocl::pfn_clReleaseProgram
+#define clReleaseKernel rj_ocl::pfn_clReleaseKernel
+#define clReleaseCommandQueue rj_ocl::pfn_clReleaseCommandQueue
+#define clReleaseContext rj_ocl::pfn_clReleaseContext
+
+// Convenience wrapper — call this once from GpuContext::init()
+static inline bool openclLoad() { return rj_ocl::load(); }
+
+#else  // not Android
+static inline bool openclLoad() { return true; } // no-op; link-time OpenCL
+#endif // __ANDROID__

--- a/ramanujan-test-codes/monte_carlo/README.md
+++ b/ramanujan-test-codes/monte_carlo/README.md
@@ -21,6 +21,19 @@ HOMELAB_READY
 HOMELAB_ADDRESS http://<server-ip>:8888
 ```
 
+To use an Android phone as the worker, connect the phone and computer to the
+same local network. In the Android app's **Server URL** field, enter the complete
+URL printed after `HOMELAB_ADDRESS`, including `http://` and port `8888`. For
+example, if the server prints:
+
+```text
+HOMELAB_ADDRESS http://192.168.1.42:8888
+```
+
+enter exactly `http://192.168.1.42:8888` and tap **Start Workers**. Do not enter
+`localhost`; on Android, `localhost` refers to the phone rather than the
+computer running `rj homelab`.
+
 Start a worker in another terminal:
 
 ```sh


### PR DESCRIPTION
This pull request adds full Android OpenCL GPU support to the Ramanujan platform, enabling Android devices to act as GPU workers for distributed computation. It introduces a new Android-specific OpenCL loader, updates documentation to guide developers through building and running the system on Android, and clarifies build flags and environment setup for GPU support on all platforms.

**Android OpenCL GPU Support and Loader Implementation**
- Introduced a new Android-specific OpenCL runtime loader in `ramanujan-native/native/opencl_loader.h`, which dynamically loads the vendor's `libOpenCL.so` and resolves all necessary OpenCL symbols at runtime, ensuring compatibility with Android's library loading mechanisms.
- Updated `NOTICE.md` to acknowledge the use of Khronos OpenCL-Headers and detail the approach for Android OpenCL support.

**Documentation and Developer Experience Improvements**
- Added a comprehensive "Contributor quick start" section to `README.md`, providing step-by-step instructions for building the developer console, native runtime, and Android app, as well as running the Monte Carlo example across desktop and Android devices.
- Expanded instructions in `ramanujan-test-codes/monte_carlo/README.md` to explain how to use an Android phone as a GPU worker, including network setup and app usage.

**Build System and Flag Consistency**
- Standardized the GPU build flag in documentation and CMake commands from `ENABLE_GPU` to `GPU_ENABLED`, ensuring consistency across all build instructions and clarifying its effect on OpenCL code inclusion. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1009-R1009) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1323-R1540)
- Updated installation instructions to remove references to unnecessary steps, streamlining the process for new contributors.